### PR TITLE
fix(smithy): clear CLAUDECODE env var to prevent nested session guard

### DIFF
--- a/packages/smithy/src/providers/claude/headless.ts
+++ b/packages/smithy/src/providers/claude/headless.ts
@@ -344,6 +344,10 @@ export class ClaudeHeadlessProvider implements HeadlessProvider {
       env.STONEFORGE_ROOT = options.stoneforgeRoot;
     }
 
+    // Clear nested-session guard so spawned Claude doesn't refuse to start.
+    // Stoneforge is an orchestrator — spawned agents are independent sessions.
+    delete env.CLAUDECODE;
+
     // Create input queue for streaming input mode
     const inputQueue = new SDKInputQueue();
 

--- a/packages/smithy/src/providers/claude/interactive.ts
+++ b/packages/smithy/src/providers/claude/interactive.ts
@@ -133,6 +133,10 @@ export class ClaudeInteractiveProvider implements InteractiveProvider {
       env.STONEFORGE_ROOT = options.stoneforgeRoot;
     }
 
+    // Clear nested-session guard so spawned Claude doesn't refuse to start.
+    // Stoneforge is an orchestrator — spawned agents are independent sessions.
+    delete env.CLAUDECODE;
+
     const cols = options.cols ?? 120;
     const rows = options.rows ?? 30;
 


### PR DESCRIPTION
## Summary

- Both `interactive.ts` and `headless.ts` providers spread `process.env` into spawned Claude processes, inheriting the `CLAUDECODE` environment variable from the parent session
- Spawned Claude detects this as a nested session and refuses to start with "cannot be launched inside another Claude Code session"
- Fix: `delete env.CLAUDECODE` after building the env object in both providers, before the environment is passed to the spawned process

Stoneforge is an orchestrator — spawned agents are independent sessions, not nested ones.

## Test plan

- [ ] Verify `sf agent start <id> --mode headless` works from inside a Claude Code session
- [ ] Verify `sf agent start <id> --mode interactive` works from inside a Claude Code session
- [ ] Verify spawned Claude processes do not have `CLAUDECODE` in their environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)