### PR TITLE
fix: allow forward slashes in baseBranch and make review branch prompt configurable

### DIFF
--- a/packages/quarry/src/config/config.bun.test.ts
+++ b/packages/quarry/src/config/config.bun.test.ts
@@ -36,6 +36,8 @@ import {
   // Validation
   isValidActor,
   validateActor,
+  isValidBaseBranch,
+  validateBaseBranch,
   isValidDatabase,
   validateDatabase,
   isValidJsonlFilename,
@@ -326,6 +328,32 @@ describe('Validation', () => {
 
     test('throws on invalid characters', () => {
       expect(() => validateActor('agent name')).toThrow(ValidationError);
+    });
+  });
+
+  describe('isValidBaseBranch', () => {
+    test('accepts standard git branch names', () => {
+      expect(isValidBaseBranch('feature/my-branch')).toBe(true);
+      expect(isValidBaseBranch('main')).toBe(true);
+    });
+
+    test('rejects invalid base branch names', () => {
+      expect(isValidBaseBranch('foo\\bar')).toBe(false);
+      expect(isValidBaseBranch('')).toBe(false);
+      expect(isValidBaseBranch(' ')).toBe(false);
+    });
+  });
+
+  describe('validateBaseBranch', () => {
+    test('returns valid base branch names', () => {
+      expect(validateBaseBranch('feature/my-branch')).toBe('feature/my-branch');
+      expect(validateBaseBranch('main')).toBe('main');
+    });
+
+    test('throws on invalid base branch names', () => {
+      expect(() => validateBaseBranch('foo\\bar')).toThrow(ValidationError);
+      expect(() => validateBaseBranch('')).toThrow(ValidationError);
+      expect(() => validateBaseBranch(' ')).toThrow(ValidationError);
     });
   });
 

--- a/packages/quarry/src/config/validation.ts
+++ b/packages/quarry/src/config/validation.ts
@@ -119,12 +119,11 @@ export function isValidBaseBranch(value: unknown): value is string {
   if (typeof value !== 'string') {
     return false;
   }
-  // Must be non-empty, no whitespace-only, no slashes that break git commands,
-  // no control characters, no spaces
+  // Must be non-empty, no whitespace-only, no backslashes,
+  // no control characters, no spaces. Forward slashes are allowed (e.g. feature/my-branch).
   return (
     value.length > 0 &&
     value.trim().length > 0 &&
-    !value.includes('/') &&
     !value.includes('\\') &&
     !/\s/.test(value) &&
     // eslint-disable-next-line no-control-regex
@@ -150,9 +149,9 @@ export function validateBaseBranch(value: unknown): string {
       { field: 'baseBranch', value }
     );
   }
-  if (value.includes('/') || value.includes('\\')) {
+  if (value.includes('\\')) {
     throw new ValidationError(
-      'baseBranch must not contain slashes',
+      'baseBranch must not contain backslashes',
       ErrorCode.INVALID_INPUT,
       { field: 'baseBranch', value }
     );

--- a/packages/smithy/src/prompts/index.bun.test.ts
+++ b/packages/smithy/src/prompts/index.bun.test.ts
@@ -399,6 +399,17 @@ describe("buildWorkflowPresetSection", () => {
     expect(section).toContain("unrestricted tool access");
   });
 
+  it("uses targetBranch in review preset instructions when provided", () => {
+    const context: WorkflowPresetContext = {
+      preset: "review",
+      permissionModel: "unrestricted",
+      targetBranch: "feature/my-branch",
+    };
+    const section = buildWorkflowPresetSection(context);
+    expect(section).toContain("feature/my-branch");
+    expect(section).not.toContain("stoneforge/review");
+  });
+
   it("returns restricted mode instructions for approve preset", () => {
     const context: WorkflowPresetContext = {
       preset: "approve",

--- a/packages/smithy/src/prompts/index.ts
+++ b/packages/smithy/src/prompts/index.ts
@@ -390,6 +390,9 @@ export interface WorkflowPresetContext {
 
   /** List of allowed bash commands (for restricted mode) */
   allowedBashCommands?: string[];
+
+  /** The configured merge target branch (e.g. 'stoneforge/review', 'feature/my-branch') */
+  targetBranch?: string | null;
 }
 
 /**
@@ -419,13 +422,15 @@ export function buildWorkflowPresetSection(context: WorkflowPresetContext): stri
       );
       break;
 
-    case 'review':
+    case 'review': {
+      const reviewBranch = context.targetBranch ?? 'stoneforge/review';
       lines.push(
-        'Your work merges to the review branch (`stoneforge/review`), not directly to main.',
+        `Your work merges to the target branch (\`${reviewBranch}\`), not directly to main.`,
         'A human will review the review branch and merge to main.',
         'You have unrestricted tool access.',
       );
       break;
+    }
 
     case 'approve': {
       // Build list of auto-allowed tools for display

--- a/packages/smithy/src/server/routes/sessions.ts
+++ b/packages/smithy/src/server/routes/sessions.ts
@@ -362,12 +362,14 @@ Please begin working on this task. Use \`sf task get ${taskResult.id}\` to see f
           if (preset) {
             const permissionModel = getValue('agents.permissionModel') as AgentPermissionModel;
             const allowedBashCommands = getValue('agents.allowedBashCommands') as string[] | undefined;
+            const targetBranch = getValue('merge.targetBranch') as string | null | undefined;
             const presetContext: WorkflowPresetContext = {
               preset,
               permissionModel,
               autoAllowedTools: AUTO_ALLOWED_TOOLS,
               autoAllowedSfCommands: AUTO_ALLOWED_SF_COMMANDS,
               allowedBashCommands: allowedBashCommands,
+              targetBranch: targetBranch ?? undefined,
             };
             const section = buildWorkflowPresetSection(presetContext);
             if (section) {

--- a/packages/smithy/src/services/dispatch-daemon.ts
+++ b/packages/smithy/src/services/dispatch-daemon.ts
@@ -3072,6 +3072,7 @@ export class DispatchDaemonImpl implements DispatchDaemon {
 
       const permissionModel = getValue('agents.permissionModel') as AgentPermissionModel;
       const allowedBashCommands = getValue('agents.allowedBashCommands') as string[] | undefined;
+      const targetBranch = getValue('merge.targetBranch') as string | null | undefined;
 
       const context: WorkflowPresetContext = {
         preset,
@@ -3079,6 +3080,7 @@ export class DispatchDaemonImpl implements DispatchDaemon {
         autoAllowedTools: AUTO_ALLOWED_TOOLS,
         autoAllowedSfCommands: AUTO_ALLOWED_SF_COMMANDS,
         allowedBashCommands: allowedBashCommands,
+        targetBranch: targetBranch ?? undefined,
       };
 
       return buildWorkflowPresetSection(context);

--- a/packages/smithy/src/services/steward-scheduler.ts
+++ b/packages/smithy/src/services/steward-scheduler.ts
@@ -1416,6 +1416,7 @@ function getWorkflowPresetSection(): string {
 
     const permissionModel = getValue('agents.permissionModel') as AgentPermissionModel;
     const allowedBashCommands = getValue('agents.allowedBashCommands') as string[] | undefined;
+    const targetBranch = getValue('merge.targetBranch') as string | null | undefined;
 
     const context: WorkflowPresetContext = {
       preset,
@@ -1423,6 +1424,7 @@ function getWorkflowPresetSection(): string {
       autoAllowedTools: AUTO_ALLOWED_TOOLS,
       autoAllowedSfCommands: AUTO_ALLOWED_SF_COMMANDS,
       allowedBashCommands: allowedBashCommands,
+      targetBranch: targetBranch ?? undefined,
     };
 
     return buildWorkflowPresetSection(context);


### PR DESCRIPTION
Closes #49

## Changes

### 1. Allow forward slashes in `baseBranch` (`@stoneforge/quarry`)

**File:** `packages/quarry/src/config/validation.ts`

Both `isValidBaseBranch()` and `validateBaseBranch()` rejected forward slashes, preventing standard Git branch names like `feature/123-my-feature` or `release/v2.0` from being used as a base branch.

Forward slashes are valid Git ref characters. Only backslashes are now rejected.

### 2. Make review branch prompt configurable (`@stoneforge/smithy`)

**Files:**
- `packages/smithy/src/prompts/index.ts` — Added `targetBranch` to `WorkflowPresetContext`, prompt now reads from it instead of hardcoding `stoneforge/review`
- `packages/smithy/src/services/dispatch-daemon.ts` — passes `merge.targetBranch` from config
- `packages/smithy/src/services/steward-scheduler.ts` — passes `merge.targetBranch` from config
- `packages/smithy/src/server/routes/sessions.ts` — passes `merge.targetBranch` from config

When a user overrides `merge.target_branch` in `config.yaml`, agent prompts now show the actual configured branch name instead of always saying `stoneforge/review`.

## Use case

Working on a feature branch (`feature/123-my-feature`) where workers create worktrees from that branch, steward merges into it, and it eventually gets a PR to main. This is common for teams batching related work before merging to main.

## Testing

- `baseBranch: "feature/my-branch"` in config.yaml now loads without error
- `baseBranch: "main"` still works (no slash)
- `baseBranch` with backslash still rejected
- Review preset prompt shows configured `targetBranch` when set, falls back to `stoneforge/review` when not set