### PR TITLE
smithy-next: Settings panel width pass + workspace icon image upload

### DIFF
--- a/apps/smithy-next/src/components/ActivityRail.tsx
+++ b/apps/smithy-next/src/components/ActivityRail.tsx
@@ -25,6 +25,7 @@ import {
 import { useState, useRef, useEffect } from 'react'
 import { Tooltip } from './Tooltip'
 import { PresenceDot } from './PresenceDot'
+import { WorkspaceIconMark, isIconImage } from './WorkspaceIconMark'
 import type { WorkspaceInfo, AppMode, StoneforgeUser } from '../mock-data'
 
 interface ActivityRailProps {
@@ -197,7 +198,9 @@ export function ActivityRail({ activeView, onNavigate, theme, onToggleTheme, wor
                   onMouseEnter={e => { if (!isActive) { e.currentTarget.style.background = 'var(--color-surface-hover)'; e.currentTarget.style.color = 'var(--color-text)' } }}
                   onMouseLeave={e => { if (!isActive) { e.currentTarget.style.background = 'var(--color-bg)'; e.currentTarget.style.color = 'var(--color-text-secondary)' } }}
                 >
-                  {ws.icon}
+                  {isIconImage(ws.icon)
+                    ? <img src={ws.icon} alt="" draggable={false} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover', borderRadius: 'var(--radius-sm)' }} />
+                    : ws.icon}
                   {/* Active indicator — left bar, colored by status */}
                   {isActive && (
                     <div style={{
@@ -296,12 +299,7 @@ export function ActivityRail({ activeView, onNavigate, theme, onToggleTheme, wor
                         onMouseEnter={e => e.currentTarget.style.background = 'var(--color-surface-hover)'}
                         onMouseLeave={e => e.currentTarget.style.background = 'transparent'}
                       >
-                        <span style={{
-                          width: 20, height: 20, borderRadius: 'var(--radius-sm)',
-                          background: 'var(--color-surface-active)', color: 'var(--color-text-secondary)',
-                          fontSize: 9, fontWeight: 700,
-                          display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-                        }}>{ws.icon}</span>
+                        <WorkspaceIconMark icon={ws.icon} size={20} fontSize={9} />
                         <div style={{ flex: 1, minWidth: 0 }}>
                           <div style={{ fontWeight: 500 }}>{ws.name}</div>
                           {ws.repo && <div style={{ fontSize: 10, color: 'var(--color-text-tertiary)', fontFamily: 'var(--font-mono)' }}>{ws.repo}</div>}

--- a/apps/smithy-next/src/components/DirectorPanel.tsx
+++ b/apps/smithy-next/src/components/DirectorPanel.tsx
@@ -45,6 +45,7 @@ import {
 import { Tooltip } from './Tooltip'
 import { AvatarStack } from './AvatarStack'
 import { UserAvatar } from './UserAvatar'
+import { WorkspaceIconMark } from './WorkspaceIconMark'
 import { useMentionAutocomplete, MentionDropdown } from './MentionAutocomplete'
 import { useTeamContext } from '../TeamContext'
 import type { DirectorSession, DirectorMessage, WorkspaceInfo, WorkspaceThread } from '../mock-data'
@@ -1260,12 +1261,7 @@ function CrossWorkspaceThreadsView({
                     transform: isOpen ? 'none' : 'rotate(-90deg)',
                     transition: 'transform var(--duration-fast)',
                   }} />
-                  <span style={{
-                    width: 18, height: 18, borderRadius: 'var(--radius-sm)',
-                    background: 'var(--color-surface-active)', color: 'var(--color-text-secondary)',
-                    fontSize: 9, fontWeight: 700,
-                    display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-                  }}>{ws.icon}</span>
+                  <WorkspaceIconMark icon={ws.icon} size={18} fontSize={9} />
                   <span style={{ flex: 1 }}>{ws.name}</span>
                   {runningCount > 0 && (
                     <span style={{ fontSize: 9, fontWeight: 600, color: 'var(--color-success)', background: 'var(--color-success-subtle)', padding: '1px 6px', borderRadius: 'var(--radius-full)' }}>

--- a/apps/smithy-next/src/components/NotificationInbox.tsx
+++ b/apps/smithy-next/src/components/NotificationInbox.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { Bell, CheckCircle2, AlertCircle, GitPullRequest, CircleDot, MessageCircle, Settings, AtSign, UserPlus, Shield } from 'lucide-react'
 import { Tooltip } from './Tooltip'
+import { WorkspaceIconMark } from './WorkspaceIconMark'
 import { TEAM_MEMBERS } from '../mock-data'
 import type { NotificationItem, WorkspaceInfo } from '../mock-data'
 
@@ -290,15 +291,7 @@ function NotificationRow({ notification, workspace, isTeamMode = false, onClick 
           {actor.avatar}
         </span>
       ) : (
-        <span style={{
-          width: 20, height: 20, borderRadius: 'var(--radius-sm)',
-          background: 'var(--color-surface-active)', color: 'var(--color-text-secondary)',
-          fontSize: 10, fontWeight: 700,
-          display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-          marginTop: 1,
-        }}>
-          {workspace?.icon || '?'}
-        </span>
+        <WorkspaceIconMark icon={workspace?.icon} size={20} fontSize={10} style={{ marginTop: 1 }} />
       )}
 
       {/* Content */}

--- a/apps/smithy-next/src/components/ToastNotifications.tsx
+++ b/apps/smithy-next/src/components/ToastNotifications.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { X, ArrowRight, CheckCircle2, AlertCircle, GitPullRequest, CircleDot, MessageCircle, Users } from 'lucide-react'
 import type { WorkspaceInfo } from '../mock-data'
 import { TEAM_MEMBERS } from '../mock-data'
+import { WorkspaceIconMark } from './WorkspaceIconMark'
 
 export interface ToastItem {
   id: string
@@ -104,14 +105,7 @@ function ToastCard({ toast, workspace, onDismiss, onSwitch }: {
     >
       {/* Header: workspace + dismiss */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-        <span style={{
-          width: 20, height: 20, borderRadius: 'var(--radius-sm)',
-          background: 'var(--color-surface-active)', color: 'var(--color-text-secondary)',
-          fontSize: 10, fontWeight: 700,
-          display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-        }}>
-          {workspace?.icon || '?'}
-        </span>
+        <WorkspaceIconMark icon={workspace?.icon} size={20} fontSize={10} />
         <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--color-text-secondary)', flex: 1 }}>
           {workspace?.name || 'Unknown'}
         </span>

--- a/apps/smithy-next/src/components/TopBar.tsx
+++ b/apps/smithy-next/src/components/TopBar.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from "./Tooltip";
 import { NotificationInbox } from "./NotificationInbox";
 import { SyncIndicator } from "./SyncIndicator";
 import { PresenceStrip } from "./PresenceStrip";
+import { WorkspaceIconMark } from "./WorkspaceIconMark";
 import type { WorkspaceInfo, NotificationItem, AppMode, SyncStatus, StoneforgeUser, PresenceEntry, WorkspaceDaemonState } from "../mock-data";
 import { mockHosts } from "./overlays/runtimes/runtime-mock-data";
 
@@ -102,22 +103,7 @@ export function TopBar({
               color: "var(--color-text)",
             }}
           >
-            <span
-              style={{
-                width: 22,
-                height: 22,
-                borderRadius: "var(--radius-sm)",
-                background: "var(--color-surface-active)",
-                color: "var(--color-text-secondary)",
-                fontSize: 11,
-                fontWeight: 700,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              {activeWorkspace.icon}
-            </span>
+            <WorkspaceIconMark icon={activeWorkspace.icon} size={22} fontSize={11} />
             <span className="workspace-name">{activeWorkspace.name}</span>
           </div>
         )}

--- a/apps/smithy-next/src/components/WorkspaceIconMark.tsx
+++ b/apps/smithy-next/src/components/WorkspaceIconMark.tsx
@@ -1,0 +1,69 @@
+import type { CSSProperties } from 'react'
+
+/**
+ * Renders a workspace icon which may be either:
+ *   - a 1–2 letter mark (e.g. "S"), or
+ *   - an uploaded image stored as a data URL ("data:image/…").
+ *
+ * The wrapper preserves the surrounding layout's width/height/border-radius
+ * so callers can style the container however they like. When the icon is an
+ * image, it fills the container with object-fit: cover.
+ */
+export function isIconImage(icon: string | null | undefined): boolean {
+  return !!icon && (icon.startsWith('data:image/') || icon.startsWith('http://') || icon.startsWith('https://'))
+}
+
+export function WorkspaceIconMark({
+  icon,
+  fallback = '?',
+  size = 24,
+  radius = 'var(--radius-sm)',
+  background = 'var(--color-surface-active)',
+  color = 'var(--color-text-secondary)',
+  fontSize,
+  fontWeight = 700,
+  style,
+}: {
+  icon: string | null | undefined
+  fallback?: string
+  size?: number
+  radius?: string | number
+  background?: string
+  color?: string
+  fontSize?: number
+  fontWeight?: number | string
+  style?: CSSProperties
+}) {
+  const isImage = isIconImage(icon)
+  const computedFontSize = fontSize ?? Math.round(size * 0.46)
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: radius,
+        background: isImage ? 'transparent' : background,
+        color,
+        fontSize: computedFontSize,
+        fontWeight,
+        flexShrink: 0,
+        overflow: 'hidden',
+        ...style,
+      }}
+    >
+      {isImage ? (
+        <img
+          src={icon as string}
+          alt=""
+          style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+          draggable={false}
+        />
+      ) : (
+        <span>{icon || fallback}</span>
+      )}
+    </div>
+  )
+}

--- a/apps/smithy-next/src/components/overlays/SettingsOverlay.tsx
+++ b/apps/smithy-next/src/components/overlays/SettingsOverlay.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useRef, useState, useMemo } from 'react'
 import {
   ArrowLeft,
   Bell,
@@ -32,11 +32,13 @@ import {
   Bot,
   AlertTriangle,
   RotateCcw,
+  Upload,
 } from 'lucide-react'
 import { useTeamContext } from '../../TeamContext'
 import { mockWorkspaces, type WorkspaceInfo } from '../../mock-data'
 import { UserAvatar } from '../UserAvatar'
 import { PresenceDot } from '../PresenceDot'
+import { WorkspaceIconMark, isIconImage } from '../WorkspaceIconMark'
 import {
   WORKFLOW_PRESETS,
   AGENT_PROVIDERS,
@@ -213,50 +215,13 @@ function GeneralSection({ appMode, onToggleMode, activeWorkspace, onUpdateActive
   const [confirmDelete, setConfirmDelete] = useState(false)
 
   return (
-    <div style={{ maxWidth: 560 }}>
+    <div style={{ maxWidth: 800 }}>
       {/* ── Workspace identity ── */}
       <SectionHeader title="Workspace" description="Identity and appearance of this workspace" />
       <div style={{ display: 'flex', flexDirection: 'column', gap: 2, marginBottom: 32 }}>
         <InputRow label="Name" placeholder="Stoneforge" value={wsName} onChange={setWsName} />
         <TextareaRow label="Description" placeholder="What this workspace is for..." value={wsDescription} onChange={setWsDescription} />
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 0' }}>
-          <span style={{ width: 100, fontSize: 12, color: 'var(--color-text-secondary)', flexShrink: 0 }}>Icon</span>
-          {/* Live badge preview — matches the style used in ActivityRail / TopBar / WorkspacesOverlay */}
-          <div style={{
-            width: 24, height: 24,
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            borderRadius: 'var(--radius-sm)',
-            background: 'var(--color-surface-active)',
-            color: 'var(--color-text-secondary)',
-            fontSize: 11, fontWeight: 700,
-            flexShrink: 0,
-          }}>
-            {wsIcon || '?'}
-          </div>
-          <input
-            value={wsIcon}
-            onChange={e => {
-              // 1–2 chars, auto-uppercase, no whitespace
-              const next = e.target.value.replace(/\s/g, '').slice(0, 2).toUpperCase()
-              setWsIcon(next)
-            }}
-            placeholder="S"
-            maxLength={2}
-            style={{
-              width: 64, height: 30, padding: '0 10px',
-              background: 'var(--color-surface)', border: '1px solid var(--color-border)',
-              borderRadius: 'var(--radius-sm)', color: 'var(--color-text)',
-              fontSize: 12, outline: 'none',
-              fontVariantCaps: 'all-small-caps',
-              transition: 'border-color var(--duration-fast)',
-            }}
-            onFocus={e => e.currentTarget.style.borderColor = 'var(--color-primary)'}
-            onBlur={e => e.currentTarget.style.borderColor = 'var(--color-border)'}
-          />
-          <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>
-            1–2 letters. Shown in the workspace switcher, notifications, and the top bar.
-          </span>
-        </div>
+        <IconRow icon={wsIcon} onChange={setWsIcon} />
       </div>
 
       {/* ── Workspace Mode ── */}
@@ -568,7 +533,7 @@ function AccountSection() {
   const { currentUser, isTeamMode, org } = useTeamContext()
 
   return (
-    <div style={{ maxWidth: 560 }}>
+    <div style={{ maxWidth: 800 }}>
       <SectionHeader title="Account" description="Your profile and connection status" />
 
       {/* Profile card */}
@@ -726,7 +691,7 @@ function OrganizationSection() {
   const planStyle = planColors[org.plan] || planColors.free
 
   return (
-    <div style={{ maxWidth: 600 }}>
+    <div style={{ maxWidth: 800 }}>
       <SectionHeader title="Organization" description="Manage your organization settings" />
 
       {/* Org header */}
@@ -1072,14 +1037,7 @@ function OrganizationSection() {
                       <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 6, marginBottom: 2 }}>Workspaces</div>
                       {workspaces.map(w => (
                         <div key={w.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                          <div style={{
-                            width: 18, height: 18, borderRadius: 'var(--radius-sm)',
-                            background: 'var(--color-surface-active)',
-                            display: 'flex', alignItems: 'center', justifyContent: 'center',
-                            fontSize: 10, fontWeight: 600, color: 'var(--color-text-secondary)',
-                          }}>
-                            {w.icon}
-                          </div>
+                          <WorkspaceIconMark icon={w.icon} size={18} fontSize={10} fontWeight={600} />
                           <span style={{ fontSize: 12, color: 'var(--color-text)' }}>{w.name}</span>
                         </div>
                       ))}
@@ -1103,14 +1061,7 @@ function OrganizationSection() {
               padding: '8px 12px',
               borderRadius: 'var(--radius-sm)',
             }}>
-              <div style={{
-                width: 22, height: 22, borderRadius: 'var(--radius-sm)',
-                background: 'var(--color-surface-active)',
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                fontSize: 11, fontWeight: 600, color: 'var(--color-text-secondary)',
-              }}>
-                {w.icon}
-              </div>
+              <WorkspaceIconMark icon={w.icon} size={22} fontSize={11} fontWeight={600} />
               <span style={{ flex: 1, fontSize: 13, color: 'var(--color-text)' }}>{w.name}</span>
               <div style={{ display: 'flex', gap: 4 }}>
                 {accessTeams.map(t => (
@@ -1155,7 +1106,7 @@ function MembersSection() {
   })
 
   return (
-    <div style={{ maxWidth: 700 }}>
+    <div style={{ maxWidth: 800 }}>
       <SectionHeader title="Members" description={`${org.members.length} members in ${org.name}`} />
 
       {/* Search + invite */}
@@ -1439,14 +1390,7 @@ function RolesAccessSection() {
                   background: 'var(--color-bg)',
                 }}>
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <div style={{
-                      width: 20, height: 20, borderRadius: 'var(--radius-sm)',
-                      background: 'var(--color-surface-active)',
-                      display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      fontSize: 10, fontWeight: 600, color: 'var(--color-text-secondary)',
-                    }}>
-                      {w.icon}
-                    </div>
+                    <WorkspaceIconMark icon={w.icon} size={20} fontSize={10} fontWeight={600} />
                     <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text)' }}>{w.name}</span>
                   </div>
                 </td>
@@ -1515,7 +1459,7 @@ function NotificationsSection() {
   const [soundEnabled, setSoundEnabled] = useState(false)
 
   return (
-    <div style={{ maxWidth: 560 }}>
+    <div style={{ maxWidth: 800 }}>
       {/* Event types */}
       <SectionHeader title="Notification events" description="Choose which events trigger notifications" />
       <div style={{ display: 'flex', flexDirection: 'column', gap: 2, marginBottom: 32 }}>
@@ -1639,7 +1583,7 @@ function IntegrationsSection() {
   }
 
   return (
-    <div style={{ maxWidth: 640 }}>
+    <div style={{ maxWidth: 800 }}>
       <IntegrationSyncGroup
         title="Issue sync"
         description="Where task issues live. Stoneforge will keep them in sync two-way."
@@ -2095,6 +2039,101 @@ function SelectRow({ label, value, options, onChange }: {
       >
         {options.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
       </select>
+    </div>
+  )
+}
+
+function IconRow({ icon, onChange }: { icon: string; onChange: (next: string) => void }) {
+  const fileRef = useRef<HTMLInputElement | null>(null)
+  const hasImage = isIconImage(icon)
+  const letterValue = hasImage ? '' : icon
+
+  const onFile = (file: File | null) => {
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      if (typeof reader.result === 'string') onChange(reader.result)
+    }
+    reader.readAsDataURL(file)
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 0' }}>
+      <span style={{ width: 100, fontSize: 12, color: 'var(--color-text-secondary)', flexShrink: 0 }}>Icon</span>
+      {/* Live preview — matches ActivityRail / TopBar / WorkspacesOverlay */}
+      <WorkspaceIconMark icon={icon} fallback="?" size={28} fontSize={11} />
+      <input
+        value={letterValue}
+        onChange={e => {
+          // 1–2 chars, auto-uppercase, no whitespace
+          const next = e.target.value.replace(/\s/g, '').slice(0, 2).toUpperCase()
+          onChange(next)
+        }}
+        placeholder="S"
+        maxLength={2}
+        disabled={hasImage}
+        title={hasImage ? 'Remove the uploaded image to edit the letter mark' : '1–2 letters'}
+        style={{
+          width: 64, height: 30, padding: '0 10px',
+          background: 'var(--color-surface)', border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius-sm)', color: 'var(--color-text)',
+          fontSize: 12, outline: 'none',
+          fontVariantCaps: 'all-small-caps',
+          transition: 'border-color var(--duration-fast)',
+          opacity: hasImage ? 0.5 : 1,
+        }}
+        onFocus={e => e.currentTarget.style.borderColor = 'var(--color-primary)'}
+        onBlur={e => e.currentTarget.style.borderColor = 'var(--color-border)'}
+      />
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/*"
+        style={{ display: 'none' }}
+        onChange={e => {
+          onFile(e.target.files?.[0] ?? null)
+          // allow re-uploading the same file
+          if (e.target) e.target.value = ''
+        }}
+      />
+      <button
+        onClick={() => fileRef.current?.click()}
+        style={{
+          height: 30, padding: '0 10px',
+          display: 'flex', alignItems: 'center', gap: 6,
+          background: 'var(--color-surface)', border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius-sm)', color: 'var(--color-text-secondary)',
+          fontSize: 12, cursor: 'pointer',
+          transition: 'all var(--duration-fast)',
+        }}
+        onMouseEnter={e => { e.currentTarget.style.background = 'var(--color-surface-hover)'; e.currentTarget.style.color = 'var(--color-text)' }}
+        onMouseLeave={e => { e.currentTarget.style.background = 'var(--color-surface)'; e.currentTarget.style.color = 'var(--color-text-secondary)' }}
+      >
+        <Upload size={12} strokeWidth={1.6} />
+        {hasImage ? 'Replace image' : 'Upload image'}
+      </button>
+      {hasImage && (
+        <button
+          onClick={() => onChange('')}
+          title="Remove image and revert to letter mark"
+          style={{
+            height: 30, padding: '0 10px',
+            display: 'flex', alignItems: 'center', gap: 4,
+            background: 'transparent', border: 'none',
+            color: 'var(--color-text-tertiary)',
+            fontSize: 12, cursor: 'pointer',
+            borderRadius: 'var(--radius-sm)',
+          }}
+          onMouseEnter={e => { e.currentTarget.style.background = 'var(--color-surface-hover)'; e.currentTarget.style.color = 'var(--color-danger)' }}
+          onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--color-text-tertiary)' }}
+        >
+          <X size={12} strokeWidth={1.8} />
+          Remove
+        </button>
+      )}
+      <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 'auto', textAlign: 'right', maxWidth: 220 }}>
+        {hasImage ? 'Custom image. Shown in the switcher, notifications, and top bar.' : '1–2 letters or an uploaded image.'}
+      </span>
     </div>
   )
 }

--- a/apps/smithy-next/src/components/overlays/WorkspacesOverlay.tsx
+++ b/apps/smithy-next/src/components/overlays/WorkspacesOverlay.tsx
@@ -16,6 +16,7 @@ import {
   X,
   Check,
 } from 'lucide-react'
+import { WorkspaceIconMark } from '../WorkspaceIconMark'
 import type { WorkspaceInfo, WorkspaceActivity } from '../../mock-data'
 import { mockWorkspaceActivity, mockWorkspaceThreads } from '../../mock-data'
 
@@ -467,12 +468,7 @@ function WorkspaceCard({ workspace, isActive, activity, threadCount, runningThre
     >
       {/* Header */}
       <div style={{ padding: '14px 16px 10px', display: 'flex', alignItems: 'flex-start', gap: 10 }}>
-        <span style={{
-          width: 28, height: 28, borderRadius: 'var(--radius-sm)',
-          background: 'var(--color-surface-active)', color: 'var(--color-text-secondary)',
-          fontSize: 12, fontWeight: 700,
-          display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-        }}>{workspace.icon}</span>
+        <WorkspaceIconMark icon={workspace.icon} size={28} fontSize={12} />
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--color-text)' }}>{workspace.name}</span>


### PR DESCRIPTION
## Summary

Follow-up to #55 covering two small UX asks on the Settings page in the \`smithy-next\` prototype:

- **Standardize all Settings panels to the same width.** Every section wrapper now uses \`maxWidth: 800\` — matching the widest panel (Roles & Access) — so content edges align consistently across tabs.
- **Let the workspace Icon setting accept an uploaded image.** The Icon row on the General tab now has an Upload image / Replace image button next to the existing 1–2-letter mark input, plus a Remove button when an image is active. The letter input is disabled while an image is present.

## Implementation notes

- New [\`WorkspaceIconMark\`](apps/smithy-next/src/components/WorkspaceIconMark.tsx) helper renders the icon as either the letter-mark span or an \`<img>\` with \`object-fit: cover\`, chosen by a small \`isIconImage()\` check (data URL or http/https).
- Data model is unchanged — \`WorkspaceInfo.icon: string\` now holds either the 1–2 letter mark or a \`data:image/…\` URL read via \`FileReader\`.
- Swapped in at every render site so uploads show up everywhere letters did: TopBar, ActivityRail (main badge + switcher list), WorkspacesOverlay card, three workspace lists inside SettingsOverlay, DirectorPanel workspace tab, NotificationInbox, ToastNotifications.

## Scope

Prototype-only; nothing here touches \`smithy-web\` production code.

## Test plan

- [ ] Open Settings, cycle through tabs — verify content columns align to the same right edge.
- [ ] On General, click \`Upload image\`, pick any PNG/JPG → preview updates, letter input disables, TopBar and Activity Rail badges both reflect the image.
- [ ] Click \`Remove\` → reverts to letter mark; letter input re-enables.
- [ ] Confirm the letter-mark flow still works (type into the input, watch badges update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)