### PR TITLE
feat(smithy,smithy-web): allow disabling agents (#58)

### DIFF
--- a/.changeset/agent-disable.md
+++ b/.changeset/agent-disable.md
@@ -1,0 +1,14 @@
+---
+"@stoneforge/smithy": minor
+---
+
+Add agent disable/enable: park agents from dispatch and scheduling without removing them from the agent list.
+
+- New `disabled?: boolean` flag on `BaseAgentMetadata`. Default omitted (treated as enabled).
+- New CLI commands `sf agent disable <id>` and `sf agent enable <id>`.
+- `sf agent list` appends `(disabled)` to the status column when set.
+- `sf agent start <id>` refuses with a hint pointing at `sf agent enable`.
+- Dispatch daemon, `getAvailableDirector` in the registry, and the steward scheduler all skip disabled agents when selecting candidates for new work.
+- In-flight sessions are NOT terminated when an agent is disabled; only future work is blocked.
+
+Closes #58.

--- a/apps/docs/src/content/docs/reference/cli-orchestration.mdx
+++ b/apps/docs/src/content/docs/reference/cli-orchestration.mdx
@@ -26,6 +26,8 @@ sf agent list [options]
 | `--reportsTo <id>` | Filter by manager entity ID |
 | `--hasSession` | Only show agents with active sessions |
 
+Disabled agents are listed alongside enabled ones, with `(disabled)` appended to their session-status column. Disabled is independent of `--status`: filtering by `--status idle` returns both disabled-and-idle and enabled-and-idle agents.
+
 Alias: `sf agents`
 
 #### `sf agent show`
@@ -96,6 +98,26 @@ sf agent stop <id> [--no-graceful] [--reason <text>]
 | `-g, --graceful` | Graceful shutdown (default: true) |
 | `--no-graceful` | Force immediate shutdown |
 | `-r, --reason <text>` | Reason for stopping |
+
+#### `sf agent disable`
+
+```bash
+sf agent disable <id>
+```
+
+Mark an agent as disabled. The agent stays visible in `sf agent list` but is skipped by the dispatch daemon, agent pool selection, `getAvailableDirector`, and the steward scheduler. In-flight sessions are NOT terminated; only future work is blocked. `sf agent start` refuses on a disabled agent.
+
+When `sf serve smithy` is reachable on `STONEFORGE_API_URL` (default `http://localhost:3457`), the CLI routes the change through the HTTP API so the running scheduler reconciles immediately (a disabled steward unregisters its cron and event triggers without an orchestrator restart). When the server is unreachable, the CLI writes the metadata directly; the scheduler picks up the change on its next start via `registerAllStewards`.
+
+Re-enable with `sf agent enable <id>`.
+
+#### `sf agent enable`
+
+```bash
+sf agent enable <id>
+```
+
+Clear the `disabled` flag on a previously-disabled agent. Same HTTP-first / direct-write reconciliation behaviour as `sf agent disable`. After enable, the agent is eligible for dispatch on the next tick and (if a steward) is re-registered with the scheduler.
 
 #### `sf agent stream`
 

--- a/apps/docs/src/content/docs/reference/orchestrator-api.mdx
+++ b/apps/docs/src/content/docs/reference/orchestrator-api.mdx
@@ -104,6 +104,46 @@ const availableWorkers = await api.getAvailableWorkers();
 const allWorkers = await api.getAgentsByRole('worker');
 ```
 
+### Disabled agents
+
+Agents carry an optional `disabled: boolean` flag on `BaseAgentMetadata`. When `true`, the agent stays visible in queries and listings but is skipped by:
+
+- `getAvailableDirector` (returns the next director that is `running` AND not disabled)
+- The dispatch daemon's worker, steward, and orphan-recovery candidate-selection loops
+- The steward scheduler's `registerSteward` (returns `false` for disabled stewards, so cron and event triggers are not registered)
+- Session start and resume routes (`POST /api/agents/:id/start` and `POST /api/agents/:id/resume` return `409 AGENT_DISABLED`)
+
+The flag does NOT terminate in-flight sessions: an agent disabled while running keeps its session until it completes or is explicitly stopped. Only future work is blocked.
+
+Read the flag through helpers rather than touching metadata directly:
+
+```typescript
+import { isAgentDisabled, isAgentEnabled, getAgentMetadata } from '@stoneforge/smithy';
+
+const agent = await api.getAgent(agentId);
+if (agent && isAgentDisabled(agent)) {
+  // Skip dispatch / start / register
+}
+
+// Equivalent inverse:
+if (agent && isAgentEnabled(agent)) { /* ... */ }
+```
+
+Toggle the flag through `updateAgentMetadata`. To enable an agent, omit the property entirely (do not set `disabled: false`) so the JSON-serialised metadata stays in the canonical absent-means-enabled shape:
+
+```typescript
+// Disable
+await api.updateAgentMetadata(agentId, { disabled: true });
+
+// Enable (delete the property)
+const meta = getAgentMetadata(agent);
+const next = { ...meta };
+delete next.disabled;
+await api.updateAgentMetadata(agentId, next);
+```
+
+The HTTP route `PATCH /api/agents/:id` accepts `{ "disabled": true | false }` and applies the same canonical shape internally; it additionally reconciles a running steward scheduler (calls `registerSteward` on enable, `unregisterSteward` on disable) so the change takes effect immediately.
+
 ---
 
 ## Agent channels

--- a/apps/smithy-web/src/api/hooks/useAgents.ts
+++ b/apps/smithy-web/src/api/hooks/useAgents.ts
@@ -491,6 +491,27 @@ export function useChangeAgentTriggers() {
 }
 
 /**
+ * Hook to disable or enable an agent.
+ * Disabled agents stay in the list but are skipped by dispatch and the steward scheduler.
+ */
+export function useToggleAgentDisabled() {
+  const queryClient = useQueryClient();
+
+  return useMutation<AgentResponse, Error, { agentId: string; disabled: boolean }>({
+    mutationFn: async ({ agentId, disabled }) => {
+      return fetchApi<AgentResponse>(`/agents/${agentId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ disabled }),
+      });
+    },
+    onSuccess: (_, { agentId }) => {
+      queryClient.invalidateQueries({ queryKey: ['agents'] });
+      queryClient.invalidateQueries({ queryKey: ['agent', agentId] });
+    },
+  });
+}
+
+/**
  * Hook to delete an agent
  */
 export function useDeleteAgent() {

--- a/apps/smithy-web/src/api/types.ts
+++ b/apps/smithy-web/src/api/types.ts
@@ -48,6 +48,8 @@ export interface BaseAgentMetadata {
   provider?: string;
   model?: string;
   executablePath?: string;
+  /** When true, the agent is parked: kept in the list but skipped by dispatch and the scheduler. */
+  disabled?: boolean;
 }
 
 export interface DirectorMetadata extends BaseAgentMetadata {

--- a/apps/smithy-web/src/components/agent/AgentCard.tsx
+++ b/apps/smithy-web/src/components/agent/AgentCard.tsx
@@ -5,12 +5,13 @@
  */
 
 import { useState, useRef, useEffect } from 'react';
-import { Play, Square, RefreshCw, Terminal, MoreVertical, Clock, GitBranch, Pencil, Inbox, Trash2, ArrowLeftRight, Settings, Zap } from 'lucide-react';
+import { Play, Square, RefreshCw, Terminal, MoreVertical, Clock, GitBranch, Pencil, Inbox, Trash2, ArrowLeftRight, Settings, Zap, Power, PowerOff } from 'lucide-react';
 import type { Agent, WorkerMetadata, StewardMetadata, SessionStatus } from '../../api/types';
 import { AgentStatusBadge } from './AgentStatusBadge';
 import { AgentRoleBadge } from './AgentRoleBadge';
 import { Tooltip } from '@stoneforge/ui';
 import { useAgentInboxCount } from '../../api/hooks/useAgentInbox';
+import { useToggleAgentDisabled } from '../../api/hooks/useAgents';
 import { AgentInboxDrawer } from './AgentInboxDrawer';
 import { ChangeProviderDialog } from './ChangeProviderDialog';
 import { getProviderLabel } from '../../lib/providers';
@@ -55,8 +56,10 @@ export function AgentCard({
 
   const agentMeta = agent.metadata?.agent;
   const isRunning = activeSessionStatus === 'running' || activeSessionStatus === 'starting';
-  const canStart = !isRunning && !isStarting;
+  const isDisabled = agentMeta?.disabled === true;
+  const canStart = !isRunning && !isStarting && !isDisabled;
   const canStop = isRunning && !isStopping;
+  const toggleDisabled = useToggleAgentDisabled();
 
   // Close menu when clicking outside
   useEffect(() => {
@@ -78,8 +81,9 @@ export function AgentCard({
 
   return (
     <div
-      className="p-4 border border-[var(--color-border)] rounded-lg bg-[var(--color-surface)] hover:border-[var(--color-border-hover)] transition-colors duration-150"
+      className={`p-4 border border-[var(--color-border)] rounded-lg bg-[var(--color-surface)] hover:border-[var(--color-border-hover)] transition-colors duration-150${isDisabled ? ' opacity-60' : ''}`}
       data-testid={`agent-card-${agent.id}`}
+      data-disabled={isDisabled || undefined}
     >
       {/* Header */}
       <div className="flex items-start justify-between gap-3">
@@ -116,6 +120,15 @@ export function AgentCard({
                 data-testid={`agent-model-${agent.id}`}
               >
                 {agentMeta.model}
+              </span>
+            )}
+            {isDisabled && (
+              <span
+                className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded bg-[var(--color-warning-muted)] text-[var(--color-warning-text)] border border-[var(--color-warning)]"
+                data-testid={`agent-disabled-badge-${agent.id}`}
+              >
+                <PowerOff className="w-3 h-3" />
+                Disabled
               </span>
             )}
           </div>
@@ -219,6 +232,25 @@ export function AgentCard({
                   Change triggers
                 </button>
               )}
+              <button
+                onClick={() => {
+                  setMenuOpen(false);
+                  toggleDisabled.mutate({ agentId: agent.id, disabled: !isDisabled });
+                }}
+                disabled={toggleDisabled.isPending}
+                className="
+                  w-full flex items-center gap-2 px-3 py-1.5 text-left text-sm
+                  text-[var(--color-text-secondary)]
+                  hover:bg-[var(--color-surface-hover)]
+                  hover:text-[var(--color-text)]
+                  whitespace-nowrap
+                  disabled:opacity-50 disabled:cursor-not-allowed
+                "
+                data-testid={`agent-toggle-disabled-${agent.id}`}
+              >
+                {isDisabled ? <Power className="w-3.5 h-3.5" /> : <PowerOff className="w-3.5 h-3.5" />}
+                {isDisabled ? 'Enable agent' : 'Disable agent'}
+              </button>
               <button
                 onClick={() => {
                   setMenuOpen(false);

--- a/apps/smithy-web/src/components/layout/DirectorPanel.tsx
+++ b/apps/smithy-web/src/components/layout/DirectorPanel.tsx
@@ -954,11 +954,13 @@ export function DirectorPanel({ collapsed = false, onToggle, isMaximized = false
                 </Tooltip>
 
                 {/* Session Controls */}
-                {!activeInfo.hasActiveSession ? (
-                  <Tooltip content="Start Session" side="bottom">
+                {(() => {
+                  const activeIsDisabled = activeInfo.director.metadata?.agent?.disabled === true;
+                  return !activeInfo.hasActiveSession ? (
+                  <Tooltip content={activeIsDisabled ? 'Director is disabled. Enable it before starting a session.' : 'Start Session'} side="bottom">
                     <button
                       onClick={handleStartActiveSession}
-                      disabled={startSessionMutation.isPending}
+                      disabled={startSessionMutation.isPending || activeIsDisabled}
                       className="p-1 rounded-md text-[var(--color-success)] hover:bg-[var(--color-surface-hover)] transition-colors duration-150 disabled:opacity-50"
                       aria-label="Start Session"
                       data-testid={`director-start-${activeDirectorId}`}
@@ -972,10 +974,10 @@ export function DirectorPanel({ collapsed = false, onToggle, isMaximized = false
                   </Tooltip>
                 ) : (
                   <>
-                    <Tooltip content="Restart Session" side="bottom">
+                    <Tooltip content={activeIsDisabled ? 'Director is disabled. Enable it before restarting.' : 'Restart Session'} side="bottom">
                       <button
                         onClick={handleRestartActiveSession}
-                        disabled={stopSessionMutation.isPending || startSessionMutation.isPending}
+                        disabled={stopSessionMutation.isPending || startSessionMutation.isPending || activeIsDisabled}
                         className="p-1 rounded-md text-[var(--color-warning)] hover:bg-[var(--color-surface-hover)] transition-colors duration-150 disabled:opacity-50"
                         aria-label="Restart Session"
                         data-testid={`director-restart-${activeDirectorId}`}
@@ -1003,7 +1005,8 @@ export function DirectorPanel({ collapsed = false, onToggle, isMaximized = false
                       </button>
                     </Tooltip>
                   </>
-                )}
+                );
+                })()}
               </>
             );
           })()}

--- a/apps/smithy-web/src/components/layout/DirectorTabContent.tsx
+++ b/apps/smithy-web/src/components/layout/DirectorTabContent.tsx
@@ -29,6 +29,7 @@ interface DirectorTabContentProps {
 export function DirectorTabContent({ info, isVisible, showMessagesQueue, onTerminalReady }: DirectorTabContentProps) {
   const { director, hasActiveSession, hasResumableSession, error } = info;
   const lastResumableSession = info.lastResumableSession as { providerSessionId?: string } | null;
+  const isDirectorDisabled = director.metadata?.agent?.disabled === true;
 
   const [terminalStatus, setTerminalStatus] = useState<TerminalStatus>('disconnected');
   const [resumeError, setResumeError] = useState<string | null>(null);
@@ -231,7 +232,8 @@ export function DirectorTabContent({ info, isVisible, showMessagesQueue, onTermi
                             <div className="flex flex-col items-center gap-3">
                               <button
                                 onClick={handleResumeSession}
-                                disabled={resumeSession.isPending || startSession.isPending}
+                                disabled={resumeSession.isPending || startSession.isPending || isDirectorDisabled}
+                                title={isDirectorDisabled ? 'Director is disabled. Enable it before resuming a session.' : undefined}
                                 className="
                                   inline-flex items-center gap-2
                                   px-5 py-2 rounded-lg
@@ -261,7 +263,8 @@ export function DirectorTabContent({ info, isVisible, showMessagesQueue, onTermi
 
                               <button
                                 onClick={handleStartSession}
-                                disabled={startSession.isPending || resumeSession.isPending}
+                                disabled={startSession.isPending || resumeSession.isPending || isDirectorDisabled}
+                                title={isDirectorDisabled ? 'Director is disabled. Enable it before starting a session.' : undefined}
                                 className="
                                   inline-flex items-center gap-2
                                   px-4 py-1.5 rounded-md

--- a/apps/smithy-web/src/components/workspace/WorkspacePane.tsx
+++ b/apps/smithy-web/src/components/workspace/WorkspacePane.tsx
@@ -13,7 +13,7 @@ import { StreamViewer } from './StreamViewer';
 import { TerminalInput } from './TerminalInput';
 import { Tooltip } from '@stoneforge/ui';
 import { SessionHistoryModal } from './SessionHistoryModal';
-import { useAgentStatus, useStartAgentSession, useStopAgentSession, useInterruptAgentSession, useResumeAgentSession } from '../../api/hooks/useAgents';
+import { useAgent, useAgentStatus, useStartAgentSession, useStopAgentSession, useInterruptAgentSession, useResumeAgentSession } from '../../api/hooks/useAgents';
 import { useAgentTokens, formatTokenCount } from '../../api/hooks/useAgentTokens';
 
 export interface WorkspacePaneProps {
@@ -92,6 +92,8 @@ export const WorkspacePane = forwardRef<WorkspacePaneHandle, WorkspacePaneProps>
 
   // Session status and controls for workers (not director - that has its own panel)
   const { data: statusData } = useAgentStatus(pane.agentRole !== 'director' ? pane.agentId : undefined);
+  const { data: agentData } = useAgent(pane.agentId);
+  const isAgentDisabled = agentData?.agent?.metadata?.agent?.disabled === true;
   const startSession = useStartAgentSession();
   const stopSession = useStopAgentSession();
   const interruptSession = useInterruptAgentSession();
@@ -337,7 +339,7 @@ export const WorkspacePane = forwardRef<WorkspacePaneHandle, WorkspacePaneProps>
                       e.stopPropagation();
                       handleStartSession();
                     }}
-                    disabled={startSession.isPending}
+                    disabled={startSession.isPending || isAgentDisabled}
                     className="
                       p-1 rounded
                       text-green-600 dark:text-green-400
@@ -345,7 +347,7 @@ export const WorkspacePane = forwardRef<WorkspacePaneHandle, WorkspacePaneProps>
                       transition-colors
                       disabled:opacity-50
                     "
-                    title="Start Session"
+                    title={isAgentDisabled ? 'Agent is disabled. Enable it before starting a session.' : 'Start Session'}
                     data-testid="pane-start-session"
                   >
                     {startSession.isPending ? (
@@ -694,7 +696,8 @@ export const WorkspacePane = forwardRef<WorkspacePaneHandle, WorkspacePaneProps>
                 {/* Start button */}
                 <button
                   onClick={handleStartSession}
-                  disabled={startSession.isPending}
+                  disabled={startSession.isPending || isAgentDisabled}
+                  title={isAgentDisabled ? 'Agent is disabled. Enable it before starting a session.' : undefined}
                   className="
                     inline-flex items-center gap-2 flex-shrink-0
                     px-4 py-2 rounded-lg

--- a/packages/smithy/src/api/orchestrator-api.ts
+++ b/packages/smithy/src/api/orchestrator-api.ts
@@ -230,6 +230,14 @@ export interface OrchestratorAPI extends QuarryAPI {
       markAsStarted?: boolean;
     }
   ): Promise<Task>;
+
+  /**
+   * Updates an agent's metadata (merges with existing metadata)
+   */
+  updateAgentMetadata(
+    agentId: EntityId,
+    updates: Partial<AgentMetadata>
+  ): Promise<AgentEntity>;
 }
 
 // ============================================================================
@@ -629,9 +637,9 @@ export class OrchestratorAPIImpl extends QuarryAPIImpl implements OrchestratorAP
   }
 
   /**
-   * Updates an agent's metadata
+   * Updates an agent's metadata (merges with existing metadata)
    */
-  private async updateAgentMetadata(
+  async updateAgentMetadata(
     agentId: EntityId,
     updates: Partial<AgentMetadata>
   ): Promise<AgentEntity> {

--- a/packages/smithy/src/cli/commands/agent.bun.test.ts
+++ b/packages/smithy/src/cli/commands/agent.bun.test.ts
@@ -2,10 +2,14 @@
  * Agent Command Tests
  *
  * Tests for orchestrator CLI agent commands structure and validation.
- * Note: Full integration tests would require database setup.
  */
 
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, test, beforeEach } from 'bun:test';
+import { createStorage, initializeSchema } from '@stoneforge/quarry';
+import { createOrchestratorAPI } from '../../api/index.js';
+import { isAgentDisabled } from '../../services/agent-registry.js';
+import type { EntityId } from '@stoneforge/core';
+import type { AgentMetadata } from '../../types/index.js';
 import {
   agentCommand,
   agentListCommand,
@@ -310,5 +314,74 @@ describe('Agent Command Validation', () => {
       expect(result.exitCode).not.toBe(0);
       expect(result.error).toContain('Usage');
     });
+  });
+});
+
+// ============================================================================
+// Behavioural round-trip tests for agent disable / enable
+//
+// The CLI handlers call createOrchestratorClient(), which runs
+// findStoneforgeDir(process.cwd()) before honouring options.db. Invoking the
+// handler literally in a test environment (no .stoneforge dir on disk) would
+// always hit the "Run sf init first" early-return path, so these tests verify
+// the mutation behaviour by calling the SAME api methods the handlers call,
+// using an in-memory SQLite backend. The handler bodies are intentionally
+// thin wrappers around api.updateAgentMetadata, so this approach gives full
+// coverage of the observable effect without duplicating handler logic.
+// ============================================================================
+
+describe('agent disable / enable behavioural', () => {
+  // Reuse the OPERATOR_ENTITY_ID constant ('el-0000') as the creator.
+  // It is a valid EntityId string - no DB row is needed for it since
+  // registerWorker only stores the value, it does not foreign-key-check it.
+  const CREATOR = 'el-0000' as EntityId;
+
+  let api: ReturnType<typeof createOrchestratorAPI>;
+  let agentId: EntityId;
+
+  beforeEach(async () => {
+    const backend = createStorage({ path: ':memory:' });
+    initializeSchema(backend);
+    api = createOrchestratorAPI(backend);
+
+    const registered = await api.registerWorker({
+      name: 'test-worker',
+      workerMode: 'ephemeral',
+      createdBy: CREATOR,
+    });
+    agentId = registered.id as unknown as EntityId;
+  });
+
+  test('disable round-trip: updateAgentMetadata sets disabled to true', async () => {
+    // This mirrors exactly what agentDisableHandler does after resolving the API.
+    await api.updateAgentMetadata(agentId, { disabled: true } as Partial<AgentMetadata>);
+
+    const agent = await api.getAgent(agentId);
+    expect(agent).toBeDefined();
+    expect((agent!.metadata.agent as { disabled?: boolean }).disabled).toBe(true);
+    expect(isAgentDisabled(agent!)).toBe(true);
+  });
+
+  test('enable round-trip: updateAgentMetadata removes disabled key from serialised JSON', async () => {
+    // First disable the agent, then re-enable it - same sequence as the two
+    // handlers called back-to-back.
+    await api.updateAgentMetadata(agentId, { disabled: true } as Partial<AgentMetadata>);
+    // Sanity-check that it is actually disabled before we enable it.
+    const disabledAgent = await api.getAgent(agentId);
+    expect(isAgentDisabled(disabledAgent!)).toBe(true);
+
+    // This mirrors exactly what agentEnableHandler does after resolving the API.
+    await api.updateAgentMetadata(agentId, { disabled: undefined } as Partial<AgentMetadata>);
+
+    const agent = await api.getAgent(agentId);
+    expect(agent).toBeDefined();
+
+    // isAgentDisabled must return false after the enable call.
+    expect(isAgentDisabled(agent!)).toBe(false);
+
+    // JSON.stringify drops undefined values, so the serialised agent metadata
+    // must contain no "disabled" key - this is the contract that
+    // absent-means-enabled relies on.
+    expect(JSON.stringify(agent!.metadata!.agent).includes('"disabled"')).toBe(false);
   });
 });

--- a/packages/smithy/src/cli/commands/agent.bun.test.ts
+++ b/packages/smithy/src/cli/commands/agent.bun.test.ts
@@ -14,6 +14,8 @@ import {
   agentStartCommand,
   agentStopCommand,
   agentStreamCommand,
+  agentDisableCommand,
+  agentEnableCommand,
 } from './agent.js';
 
 describe('Agent Command Structure', () => {
@@ -31,6 +33,8 @@ describe('Agent Command Structure', () => {
       expect(agentCommand.subcommands!.start).toBe(agentStartCommand);
       expect(agentCommand.subcommands!.stop).toBe(agentStopCommand);
       expect(agentCommand.subcommands!.stream).toBe(agentStreamCommand);
+      expect(agentCommand.subcommands!.disable).toBe(agentDisableCommand);
+      expect(agentCommand.subcommands!.enable).toBe(agentEnableCommand);
     });
 
     it('should default to list handler', () => {
@@ -219,6 +223,24 @@ describe('Agent Command Structure', () => {
       expect(typeof agentStreamCommand.handler).toBe('function');
     });
   });
+
+  describe('agentDisableCommand', () => {
+    it('should have correct structure', () => {
+      expect(agentDisableCommand.name).toBe('disable');
+      expect(agentDisableCommand.description).toBe('Disable an agent (skipped by dispatch and scheduler, kept in the list)');
+      expect(agentDisableCommand.usage).toBe('sf agent disable <id>');
+      expect(typeof agentDisableCommand.handler).toBe('function');
+    });
+  });
+
+  describe('agentEnableCommand', () => {
+    it('should have correct structure', () => {
+      expect(agentEnableCommand.name).toBe('enable');
+      expect(agentEnableCommand.description).toBe('Enable a previously disabled agent');
+      expect(agentEnableCommand.usage).toBe('sf agent enable <id>');
+      expect(typeof agentEnableCommand.handler).toBe('function');
+    });
+  });
 });
 
 describe('Agent Command Validation', () => {
@@ -269,6 +291,22 @@ describe('Agent Command Validation', () => {
   describe('agentStreamCommand', () => {
     it('should fail without id argument', async () => {
       const result = await agentStreamCommand.handler([], {});
+      expect(result.exitCode).not.toBe(0);
+      expect(result.error).toContain('Usage');
+    });
+  });
+
+  describe('agentDisableCommand', () => {
+    it('should fail without id argument', async () => {
+      const result = await agentDisableCommand.handler([], {});
+      expect(result.exitCode).not.toBe(0);
+      expect(result.error).toContain('Usage');
+    });
+  });
+
+  describe('agentEnableCommand', () => {
+    it('should fail without id argument', async () => {
+      const result = await agentEnableCommand.handler([], {});
       expect(result.exitCode).not.toBe(0);
       expect(result.error).toContain('Usage');
     });

--- a/packages/smithy/src/cli/commands/agent.bun.test.ts
+++ b/packages/smithy/src/cli/commands/agent.bun.test.ts
@@ -5,6 +5,9 @@
  */
 
 import { describe, it, expect, test, beforeEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createStorage, initializeSchema } from '@stoneforge/quarry';
 import { createOrchestratorAPI } from '../../api/index.js';
 import { isAgentDisabled } from '../../services/agent-registry.js';
@@ -383,5 +386,48 @@ describe('agent disable / enable behavioural', () => {
     // must contain no "disabled" key - this is the contract that
     // absent-means-enabled relies on.
     expect(JSON.stringify(agent!.metadata!.agent).includes('"disabled"')).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // agentStartHandler refusal test
+  //
+  // createOrchestratorClient calls findStoneforgeDir(process.cwd()), so we
+  // chdir into a tmpdir that has a .stoneforge subdir containing a real SQLite
+  // DB. This lets us exercise the actual handler code path (including the
+  // isAgentDisabled guard) without spawning a process.
+  // -------------------------------------------------------------------------
+  test('start refuses on a disabled agent', async () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'sf-disable-test-'));
+    const cwdBefore = process.cwd();
+    try {
+      mkdirSync(join(tmpRoot, '.stoneforge'), { recursive: true });
+      const dbPath = join(tmpRoot, '.stoneforge', 'stoneforge.db');
+      const tmpBackend = createStorage({ path: dbPath, create: true });
+      initializeSchema(tmpBackend);
+      const tmpApi = createOrchestratorAPI(tmpBackend);
+      const registered = await tmpApi.registerWorker({
+        name: 'disabled-worker',
+        workerMode: 'ephemeral',
+        createdBy: CREATOR,
+      });
+      // Disable the agent via the API (same as agentDisableHandler would do).
+      await tmpApi.updateAgentMetadata(registered.id as unknown as EntityId, { disabled: true } as Partial<AgentMetadata>);
+
+      process.chdir(tmpRoot);
+      try {
+        const result = await agentStartCommand.handler!(
+          [registered.id as unknown as string],
+          { db: dbPath } as never
+        );
+        expect(result.exitCode).not.toBe(0);
+        const errMsg = String(result.error ?? '');
+        expect(errMsg.toLowerCase()).toContain('disabled');
+        expect(errMsg).toContain('sf agent enable');
+      } finally {
+        process.chdir(cwdBefore);
+      }
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/smithy/src/cli/commands/agent.bun.test.ts
+++ b/packages/smithy/src/cli/commands/agent.bun.test.ts
@@ -389,6 +389,58 @@ describe('agent disable / enable behavioural', () => {
   });
 
   // -------------------------------------------------------------------------
+  // agentListHandler annotation test
+  //
+  // chdir into a tmpdir with a real .stoneforge/stoneforge.db so that
+  // createOrchestratorClient can resolve the DB and the handler runs end-to-end.
+  // -------------------------------------------------------------------------
+  test('list output marks disabled agents', async () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'sf-disable-list-'));
+    try {
+      mkdirSync(join(tmpRoot, '.stoneforge'), { recursive: true });
+      const dbPath = join(tmpRoot, '.stoneforge', 'stoneforge.db');
+      const tmpBackend = createStorage({ path: dbPath, create: true });
+      initializeSchema(tmpBackend);
+      const tmpApi = createOrchestratorAPI(tmpBackend);
+
+      await tmpApi.registerWorker({
+        name: 'enabled-w',
+        workerMode: 'ephemeral',
+        createdBy: CREATOR,
+      });
+      const disabledRegistered = await tmpApi.registerWorker({
+        name: 'disabled-w',
+        workerMode: 'ephemeral',
+        createdBy: CREATOR,
+      });
+      await tmpApi.updateAgentMetadata(
+        disabledRegistered.id as unknown as EntityId,
+        { disabled: true } as Partial<AgentMetadata>
+      );
+
+      const cwdBefore = process.cwd();
+      process.chdir(tmpRoot);
+      try {
+        const result = await agentListCommand.handler!([], { db: dbPath } as never);
+        expect(result.exitCode).toBe(0);
+        const out = String(result.message ?? '');
+        // Disabled agent should have (disabled) in its row
+        const disabledLine = out.split('\n').find(l => l.includes('disabled-w'));
+        expect(disabledLine).toBeTruthy();
+        expect(disabledLine).toContain('(disabled)');
+        // Enabled agent must NOT have the marker
+        const enabledLine = out.split('\n').find(l => l.includes('enabled-w'));
+        expect(enabledLine).toBeTruthy();
+        expect(enabledLine).not.toContain('(disabled)');
+      } finally {
+        process.chdir(cwdBefore);
+      }
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
   // agentStartHandler refusal test
   //
   // createOrchestratorClient calls findStoneforgeDir(process.cwd()), so we

--- a/packages/smithy/src/cli/commands/agent.ts
+++ b/packages/smithy/src/cli/commands/agent.ts
@@ -13,7 +13,7 @@
 import type { Command, GlobalOptions, CommandResult, CommandOption } from '@stoneforge/quarry/cli';
 import { success, failure, ExitCode, getFormatter, getOutputMode, OPERATOR_ENTITY_ID } from '@stoneforge/quarry/cli';
 import type { EntityId, ElementId } from '@stoneforge/core';
-import type { AgentRole, WorkerMode, StewardFocus } from '../../types/index.js';
+import type { AgentRole, WorkerMode, StewardFocus, AgentMetadata } from '../../types/index.js';
 import type { OrchestratorAPI, AgentEntity } from '../../api/index.js';
 
 // ============================================================================
@@ -1047,6 +1047,72 @@ Examples:
 };
 
 // ============================================================================
+// Agent Disable Command
+// ============================================================================
+
+async function agentDisableHandler(
+  args: string[],
+  options: GlobalOptions
+): Promise<CommandResult> {
+  const [id] = args;
+  if (!id) {
+    return failure('Usage: sf agent disable <id>', ExitCode.INVALID_ARGUMENTS);
+  }
+  const { api, error } = await createOrchestratorClient(options);
+  if (error || !api) return failure(error ?? 'Failed to create API', ExitCode.GENERAL_ERROR);
+
+  const agent = await api.getAgent(id as EntityId);
+  if (!agent) return failure(`Agent not found: ${id}`, ExitCode.NOT_FOUND);
+
+  await api.updateAgentMetadata(id as EntityId, { disabled: true } as Partial<AgentMetadata>);
+  return success({ id, disabled: true }, `Agent ${id} disabled. It will be skipped by dispatch and the scheduler.`);
+}
+
+export const agentDisableCommand: Command = {
+  name: 'disable',
+  description: 'Disable an agent (skipped by dispatch and scheduler, kept in the list)',
+  usage: 'sf agent disable <id>',
+  help: `Mark an agent as disabled. The agent stays visible in 'sf agent list' but is skipped by the dispatch daemon and steward scheduler. In-flight sessions are NOT terminated; only future work is blocked. Re-enable with 'sf agent enable <id>'.
+
+Arguments:
+  id    Agent identifier`,
+  handler: agentDisableHandler as Command['handler'],
+};
+
+// ============================================================================
+// Agent Enable Command
+// ============================================================================
+
+async function agentEnableHandler(
+  args: string[],
+  options: GlobalOptions
+): Promise<CommandResult> {
+  const [id] = args;
+  if (!id) {
+    return failure('Usage: sf agent enable <id>', ExitCode.INVALID_ARGUMENTS);
+  }
+  const { api, error } = await createOrchestratorClient(options);
+  if (error || !api) return failure(error ?? 'Failed to create API', ExitCode.GENERAL_ERROR);
+
+  const agent = await api.getAgent(id as EntityId);
+  if (!agent) return failure(`Agent not found: ${id}`, ExitCode.NOT_FOUND);
+
+  await api.updateAgentMetadata(id as EntityId, { disabled: undefined } as Partial<AgentMetadata>);
+  return success({ id, disabled: false }, `Agent ${id} enabled.`);
+}
+
+export const agentEnableCommand: Command = {
+  name: 'enable',
+  description: 'Enable a previously disabled agent',
+  usage: 'sf agent enable <id>',
+  help: `Re-enable a disabled agent so it is considered again by dispatch and the scheduler.
+
+Arguments:
+  id    Agent identifier`,
+  handler: agentEnableHandler as Command['handler'],
+};
+
+// ============================================================================
 // Main Agent Command
 // ============================================================================
 
@@ -1063,6 +1129,8 @@ Subcommands:
   start     Start an agent process
   stop      Stop an agent session
   stream    Get agent channel for streaming
+  disable   Disable an agent (skipped by dispatch and scheduler)
+  enable    Re-enable a previously disabled agent
 
 Examples:
   sf agent list
@@ -1076,6 +1144,8 @@ Examples:
     start: agentStartCommand,
     stop: agentStopCommand,
     stream: agentStreamCommand,
+    disable: agentDisableCommand,
+    enable: agentEnableCommand,
     // Aliases (hidden from --help via dedup in getCommandHelp)
     create: agentRegisterCommand,
     ls: agentListCommand,

--- a/packages/smithy/src/cli/commands/agent.ts
+++ b/packages/smithy/src/cli/commands/agent.ts
@@ -1060,6 +1060,36 @@ Examples:
 // Agent Disable Command
 // ============================================================================
 
+/**
+ * Tries to apply a disabled-flag change through the running orchestrator's
+ * PATCH /api/agents/:id endpoint so an active scheduler can reconcile (e.g.
+ * unregister a steward's cron jobs immediately). Returns true on success,
+ * false on any failure (server unreachable, non-2xx, network error, timeout)
+ * so the caller can fall back to a direct DB write. The CLI must produce a
+ * consistent end state whether the orchestrator is up or not.
+ */
+async function tryReconcileDisabledViaServer(
+  id: string,
+  disabled: boolean
+): Promise<boolean> {
+  const apiUrl = (process.env.STONEFORGE_API_URL || 'http://localhost:3457').replace(/\/$/, '');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1500);
+  try {
+    const response = await fetch(`${apiUrl}/api/agents/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled }),
+      signal: controller.signal,
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function agentDisableHandler(
   args: string[],
   options: GlobalOptions
@@ -1068,6 +1098,14 @@ async function agentDisableHandler(
   if (!id) {
     return failure('Usage: sf agent disable <id>', ExitCode.INVALID_ARGUMENTS);
   }
+
+  // Try the running server first so an active scheduler reconciles steward
+  // triggers immediately. If unreachable, fall back to direct DB write.
+  const reconciled = await tryReconcileDisabledViaServer(id, true);
+  if (reconciled) {
+    return success({ id, disabled: true }, `Agent ${id} disabled. It will be skipped by dispatch and the scheduler.`);
+  }
+
   const { api, error } = await createOrchestratorClient(options);
   if (error || !api) return failure(error ?? 'Failed to create API', ExitCode.GENERAL_ERROR);
 
@@ -1075,7 +1113,7 @@ async function agentDisableHandler(
   if (!agent) return failure(`Agent not found: ${id}`, ExitCode.NOT_FOUND);
 
   await api.updateAgentMetadata(id as EntityId, { disabled: true } as Partial<AgentMetadata>);
-  return success({ id, disabled: true }, `Agent ${id} disabled. It will be skipped by dispatch and the scheduler.`);
+  return success({ id, disabled: true }, `Agent ${id} disabled. Scheduler will pick up the change on next start.`);
 }
 
 export const agentDisableCommand: Command = {
@@ -1101,6 +1139,14 @@ async function agentEnableHandler(
   if (!id) {
     return failure('Usage: sf agent enable <id>', ExitCode.INVALID_ARGUMENTS);
   }
+
+  // Try the running server first so an active scheduler re-registers a
+  // steward's triggers immediately. If unreachable, fall back to direct DB write.
+  const reconciled = await tryReconcileDisabledViaServer(id, false);
+  if (reconciled) {
+    return success({ id, disabled: false }, `Agent ${id} enabled.`);
+  }
+
   const { api, error } = await createOrchestratorClient(options);
   if (error || !api) return failure(error ?? 'Failed to create API', ExitCode.GENERAL_ERROR);
 
@@ -1108,7 +1154,7 @@ async function agentEnableHandler(
   if (!agent) return failure(`Agent not found: ${id}`, ExitCode.NOT_FOUND);
 
   await api.updateAgentMetadata(id as EntityId, { disabled: undefined } as Partial<AgentMetadata>);
-  return success({ id, disabled: false }, `Agent ${id} enabled.`);
+  return success({ id, disabled: false }, `Agent ${id} enabled. Scheduler will pick up the change on next start.`);
 }
 
 export const agentEnableCommand: Command = {

--- a/packages/smithy/src/cli/commands/agent.ts
+++ b/packages/smithy/src/cli/commands/agent.ts
@@ -15,6 +15,7 @@ import { success, failure, ExitCode, getFormatter, getOutputMode, OPERATOR_ENTIT
 import type { EntityId, ElementId } from '@stoneforge/core';
 import type { AgentRole, WorkerMode, StewardFocus, AgentMetadata } from '../../types/index.js';
 import type { OrchestratorAPI, AgentEntity } from '../../api/index.js';
+import { isAgentDisabled } from '../../services/agent-registry.js';
 
 // ============================================================================
 // Shared Helpers
@@ -900,6 +901,13 @@ async function agentStartHandler(
     const agent = await api.getAgent(id as EntityId);
     if (!agent) {
       return failure(`Agent not found: ${id}`, ExitCode.NOT_FOUND);
+    }
+
+    if (isAgentDisabled(agent)) {
+      return failure(
+        `Agent ${id} is disabled. Run 'sf agent enable ${id}' first to bring it back online.`,
+        ExitCode.VALIDATION
+      );
     }
 
     const meta = getAgentMeta(agent);

--- a/packages/smithy/src/cli/commands/agent.ts
+++ b/packages/smithy/src/cli/commands/agent.ts
@@ -274,11 +274,13 @@ async function agentListHandler(
     const headers = ['ID', 'NAME', 'ROLE', 'STATUS', 'SESSION'];
     const rows = agents.map((agent) => {
       const meta = getAgentMeta(agent);
+      const baseStatus = (meta.sessionStatus as string) ?? 'idle';
+      const status = meta.disabled === true ? `${baseStatus} (disabled)` : baseStatus;
       return [
         agent.id,
         agent.name ?? '-',
         (meta.agentRole as string) ?? '-',
-        (meta.sessionStatus as string) ?? 'idle',
+        status,
         (meta.sessionId as string)?.slice(0, 8) ?? '-',
       ];
     });

--- a/packages/smithy/src/server/routes/agents.test.ts
+++ b/packages/smithy/src/server/routes/agents.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Agent Routes Tests — PATCH /api/agents/:id disabled handling
+ *
+ * Covers the disabled-flag plumbing on the PATCH route:
+ * - boolean validation (400 on non-boolean)
+ * - metadata write through agentRegistry.updateAgentMetadata
+ * - live scheduler reconciliation for stewards (register on enable, unregister on disable)
+ * - non-steward agents do NOT touch the scheduler
+ * - scheduler errors are warning-swallowed and do not fail the request
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTimestamp } from '@stoneforge/core';
+import type { ElementId, EntityId } from '@stoneforge/core';
+import type { Services } from '../services.js';
+import { createAgentRoutes } from './agents.js';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+interface MinimalAgent {
+  id: ElementId;
+  name: string;
+  metadata: { agent: { agentRole: 'director' | 'worker' | 'steward'; sessionStatus?: string; workerMode?: string; stewardFocus?: string; disabled?: boolean } };
+}
+
+function createMockAgent(role: 'director' | 'worker' | 'steward', overrides: Partial<MinimalAgent> = {}): MinimalAgent {
+  const baseMeta: MinimalAgent['metadata']['agent'] = {
+    agentRole: role,
+    sessionStatus: 'idle',
+    ...(role === 'worker' ? { workerMode: 'ephemeral' as const } : {}),
+    ...(role === 'steward' ? { stewardFocus: 'merge' as const } : {}),
+  };
+  return {
+    id: 'agent-001' as ElementId,
+    name: `Test-${role}`,
+    metadata: { agent: baseMeta },
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Mock Services Factory
+// ============================================================================
+
+function createMockServices() {
+  const agentRegistry = {
+    getAgent: vi.fn(),
+    listAgents: vi.fn(),
+    getAgentsByRole: vi.fn(),
+    updateAgent: vi.fn(),
+    updateAgentMetadata: vi.fn(),
+  };
+
+  const stewardScheduler = {
+    isRunning: vi.fn().mockReturnValue(true),
+    registerSteward: vi.fn().mockResolvedValue(true),
+    unregisterSteward: vi.fn().mockResolvedValue(true),
+    refreshSteward: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const sessionManager = {
+    getActiveSession: vi.fn(),
+  };
+
+  const services = {
+    agentRegistry,
+    sessionManager,
+    taskAssignmentService: {},
+    stewardScheduler,
+  } as unknown as Services;
+
+  return { services, agentRegistry, stewardScheduler };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('PATCH /api/agents/:id — disabled flag', () => {
+  let services: Services;
+  let agentRegistry: ReturnType<typeof createMockServices>['agentRegistry'];
+  let stewardScheduler: ReturnType<typeof createMockServices>['stewardScheduler'];
+
+  beforeEach(() => {
+    const mocks = createMockServices();
+    services = mocks.services;
+    agentRegistry = mocks.agentRegistry;
+    stewardScheduler = mocks.stewardScheduler;
+  });
+
+  it('accepts disabled: true and writes through updateAgentMetadata', async () => {
+    const agent = createMockAgent('worker');
+    agentRegistry.getAgent.mockResolvedValue(agent);
+    agentRegistry.updateAgentMetadata.mockResolvedValue(agent);
+
+    const app = createAgentRoutes(services);
+    const res = await app.request('/api/agents/agent-001', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled: true }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(agentRegistry.updateAgentMetadata).toHaveBeenCalledWith('agent-001', { disabled: true });
+  });
+
+  it('accepts disabled: false and writes the absent-means-enabled shape', async () => {
+    const agent = createMockAgent('worker');
+    agentRegistry.getAgent.mockResolvedValue(agent);
+    agentRegistry.updateAgentMetadata.mockResolvedValue(agent);
+
+    const app = createAgentRoutes(services);
+    const res = await app.request('/api/agents/agent-001', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled: false }),
+    });
+
+    expect(res.status).toBe(200);
+    // false should produce undefined so JSON.stringify drops the key on persist
+    expect(agentRegistry.updateAgentMetadata).toHaveBeenCalledWith('agent-001', { disabled: undefined });
+  });
+
+  it('rejects non-boolean disabled with 400 VALIDATION_ERROR', async () => {
+    const agent = createMockAgent('worker');
+    agentRegistry.getAgent.mockResolvedValue(agent);
+
+    const app = createAgentRoutes(services);
+    const res = await app.request('/api/agents/agent-001', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled: 'yes' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error?.code).toBe('VALIDATION_ERROR');
+    expect(body.error?.message).toMatch(/boolean/i);
+    expect(agentRegistry.updateAgentMetadata).not.toHaveBeenCalled();
+  });
+
+  it('unregisters a steward from the scheduler when disabling', async () => {
+    const steward = createMockAgent('steward');
+    agentRegistry.getAgent.mockResolvedValue(steward);
+    // After update, the agent's metadata reflects disabled: true and role: steward
+    agentRegistry.updateAgentMetadata.mockResolvedValue({
+      ...steward,
+      metadata: { agent: { ...steward.metadata.agent, disabled: true } },
+    });
+
+    const app = createAgentRoutes(services);
+    const res = await app.request('/api/agents/agent-001', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled: true }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(stewardScheduler.unregisterSteward).toHaveBeenCalledWith('agent-001');
+    expect(stewardScheduler.registerSteward).not.toHaveBeenCalled();
+  });
+
+  it('registers a steward with the scheduler when enabling', async () => {
+    const steward = createMockAgent('steward');
+    agentRegistry.getAgent.mockResolvedValue(steward);
+    agentRegistry.updateAgentMetadata.mockResolvedValue(steward);
+
+    const app = createAgentRoutes(services);
+    const res = await app.request('/api/agents/agent-001', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled: false }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(stewardScheduler.registerSteward).toHaveBeenCalledWith('agent-001');
+    expect(stewardScheduler.unregisterSteward).not.toHaveBeenCalled();
+  });
+
+  it('does not touch the scheduler for non-steward agents (worker)', async () => {
+    const worker = createMockAgent('worker');
+    agentRegistry.getAgent.mockResolvedValue(worker);
+    agentRegistry.updateAgentMetadata.mockResolvedValue(worker);
+
+    const app = createAgentRoutes(services);
+    const res = await app.request('/api/agents/agent-001', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled: true }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(stewardScheduler.unregisterSteward).not.toHaveBeenCalled();
+    expect(stewardScheduler.registerSteward).not.toHaveBeenCalled();
+  });
+
+  it('does not touch the scheduler when it is not running', async () => {
+    const steward = createMockAgent('steward');
+    agentRegistry.getAgent.mockResolvedValue(steward);
+    agentRegistry.updateAgentMetadata.mockResolvedValue({
+      ...steward,
+      metadata: { agent: { ...steward.metadata.agent, disabled: true } },
+    });
+    stewardScheduler.isRunning.mockReturnValue(false);
+
+    const app = createAgentRoutes(services);
+    const res = await app.request('/api/agents/agent-001', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled: true }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(stewardScheduler.unregisterSteward).not.toHaveBeenCalled();
+    expect(stewardScheduler.registerSteward).not.toHaveBeenCalled();
+  });
+
+  it('swallows scheduler errors and still returns 200', async () => {
+    const steward = createMockAgent('steward');
+    agentRegistry.getAgent.mockResolvedValue(steward);
+    agentRegistry.updateAgentMetadata.mockResolvedValue({
+      ...steward,
+      metadata: { agent: { ...steward.metadata.agent, disabled: true } },
+    });
+    stewardScheduler.unregisterSteward.mockRejectedValue(new Error('scheduler kaboom'));
+
+    const app = createAgentRoutes(services);
+    const res = await app.request('/api/agents/agent-001', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled: true }),
+    });
+
+    expect(res.status).toBe(200);
+    // metadata write should still have happened despite the scheduler failure
+    expect(agentRegistry.updateAgentMetadata).toHaveBeenCalledWith('agent-001', { disabled: true });
+  });
+
+  it('returns 404 for an unknown agent', async () => {
+    agentRegistry.getAgent.mockResolvedValue(undefined);
+
+    const app = createAgentRoutes(services);
+    const res = await app.request('/api/agents/missing', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled: true }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error?.code).toBe('NOT_FOUND');
+    expect(agentRegistry.updateAgentMetadata).not.toHaveBeenCalled();
+  });
+});
+
+// Reference unused symbols that come from @stoneforge/core to satisfy the
+// import at the top while keeping the test fixture lean.
+void createTimestamp;
+void (null as unknown as EntityId);

--- a/packages/smithy/src/server/routes/agents.test.ts
+++ b/packages/smithy/src/server/routes/agents.test.ts
@@ -10,8 +10,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createTimestamp } from '@stoneforge/core';
-import type { ElementId, EntityId } from '@stoneforge/core';
+import type { ElementId } from '@stoneforge/core';
 import type { Services } from '../services.js';
 import { createAgentRoutes } from './agents.js';
 
@@ -254,8 +253,3 @@ describe('PATCH /api/agents/:id — disabled flag', () => {
     expect(agentRegistry.updateAgentMetadata).not.toHaveBeenCalled();
   });
 });
-
-// Reference unused symbols that come from @stoneforge/core to satisfy the
-// import at the top while keeping the test fixture lean.
-void createTimestamp;
-void (null as unknown as EntityId);

--- a/packages/smithy/src/server/routes/agents.ts
+++ b/packages/smithy/src/server/routes/agents.ts
@@ -313,6 +313,7 @@ export function createAgentRoutes(services: Services) {
         executablePath?: string | null;
         targetBranch?: string | null;
         triggers?: Array<{ type: 'cron'; schedule: string } | { type: 'event'; event: string; condition?: string }>;
+        disabled?: boolean;
       };
 
       const agent = await agentRegistry.getAgent(agentId);
@@ -338,6 +339,10 @@ export function createAgentRoutes(services: Services) {
 
       if (body.targetBranch !== undefined && body.targetBranch !== null && (typeof body.targetBranch !== 'string' || body.targetBranch.trim().length === 0)) {
         return c.json({ error: { code: 'VALIDATION_ERROR', message: 'targetBranch must be a non-empty string or null' } }, 400);
+      }
+
+      if (body.disabled !== undefined && typeof body.disabled !== 'boolean') {
+        return c.json({ error: { code: 'VALIDATION_ERROR', message: 'disabled must be a boolean' } }, 400);
       }
 
       // Update name if provided
@@ -404,6 +409,27 @@ export function createAgentRoutes(services: Services) {
             await stewardScheduler.registerSteward(agentId);
           } catch (err) {
             logger.warn('Failed to re-register steward with scheduler after trigger update:', err);
+          }
+        }
+      }
+
+      // Toggle disabled flag. Setting to false drops the property so the absent-means-enabled
+      // contract holds in the JSON-serialised metadata. Stewards re-register or unregister
+      // immediately so a running scheduler does not need a restart.
+      if (body.disabled !== undefined) {
+        updatedAgent = await agentRegistry.updateAgentMetadata(agentId, {
+          disabled: body.disabled === false ? undefined : true,
+        });
+        const isSteward = updatedAgent.metadata?.agent?.agentRole === 'steward';
+        if (isSteward && stewardScheduler.isRunning()) {
+          try {
+            if (body.disabled) {
+              await stewardScheduler.unregisterSteward(agentId);
+            } else {
+              await stewardScheduler.registerSteward(agentId);
+            }
+          } catch (err) {
+            logger.warn('Failed to update steward scheduler state after disabled toggle:', err);
           }
         }
       }

--- a/packages/smithy/src/server/routes/sessions.ts
+++ b/packages/smithy/src/server/routes/sessions.ts
@@ -10,6 +10,7 @@ import type { EntityId, ElementId, Task } from '@stoneforge/core';
 import { createTimestamp, ElementType } from '@stoneforge/core';
 import type { SessionFilter, SpawnedSessionEvent, AgentRole, WorkerMetadata, StewardMetadata } from '../../index.js';
 import { loadRolePrompt, buildWorkflowPresetSection, getAgentMetadata, generateSessionBranchName, generateSessionWorktreePath, trackListeners } from '../../index.js';
+import { isAgentDisabled } from '../../services/agent-registry.js';
 import type { WorkflowPresetContext } from '../../prompts/index.js';
 import { getValue } from '@stoneforge/quarry';
 import type { WorkflowPreset, AgentPermissionModel } from '@stoneforge/quarry';
@@ -234,6 +235,18 @@ export function createSessionRoutes(
       const agent = await agentRegistry.getAgent(agentId);
       if (!agent) {
         return c.json({ error: { code: 'NOT_FOUND', message: 'Agent not found' } }, 404);
+      }
+
+      if (isAgentDisabled(agent)) {
+        return c.json(
+          {
+            error: {
+              code: 'AGENT_DISABLED',
+              message: `Agent ${agentId} is disabled. Enable it before starting a session.`,
+            },
+          },
+          409
+        );
       }
 
       const existingSession = sessionManager.getActiveSession(agentId);
@@ -558,6 +571,18 @@ Please begin working on this task. Use \`sf task get ${taskResult.id}\` to see f
       const agent = await agentRegistry.getAgent(agentId);
       if (!agent) {
         return c.json({ error: { code: 'NOT_FOUND', message: 'Agent not found' } }, 404);
+      }
+
+      if (isAgentDisabled(agent)) {
+        return c.json(
+          {
+            error: {
+              code: 'AGENT_DISABLED',
+              message: `Agent ${agentId} is disabled. Enable it before resuming a session.`,
+            },
+          },
+          409
+        );
       }
 
       const existingSession = sessionManager.getActiveSession(agentId);

--- a/packages/smithy/src/services/agent-registry.bun.test.ts
+++ b/packages/smithy/src/services/agent-registry.bun.test.ts
@@ -726,3 +726,55 @@ describe('isAgentDisabled / isAgentEnabled', () => {
     expect(isAgentEnabled(enabled as never)).toBe(true);
   });
 });
+
+describe('getAvailableDirector with disabled', () => {
+  let registry: AgentRegistry;
+  let api: QuarryAPI;
+  let testDbPath: string;
+  let systemEntity: EntityId;
+
+  beforeEach(async () => {
+    testDbPath = `/tmp/agent-registry-director-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+    const storage = createStorage(testDbPath);
+    initializeSchema(storage);
+    api = createQuarryAPI(storage);
+    registry = createAgentRegistry(api);
+
+    const entity = await createEntity({
+      name: 'test-system',
+      entityType: EntityTypeValue.SYSTEM,
+      createdBy: 'system:test' as EntityId,
+    });
+    const saved = await api.create(entity as unknown as Record<string, unknown> & { createdBy: EntityId });
+    systemEntity = saved.id as unknown as EntityId;
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testDbPath)) {
+      fs.unlinkSync(testDbPath);
+    }
+  });
+
+  test('does not return a disabled director even if its session is running', async () => {
+    const enabled = await registry.registerDirector({
+      name: 'CEO-1',
+      createdBy: systemEntity,
+    });
+    const disabled = await registry.registerDirector({
+      name: 'CEO-2',
+      createdBy: systemEntity,
+    });
+
+    // Mark both as running, then mark the second as disabled.
+    await registry.updateAgentMetadata(enabled.id as unknown as EntityId, {
+      sessionStatus: 'running',
+    } as never);
+    await registry.updateAgentMetadata(disabled.id as unknown as EntityId, {
+      sessionStatus: 'running',
+      disabled: true,
+    } as never);
+
+    const result = await registry.getAvailableDirector();
+    expect(result?.id).toBe(enabled.id);
+  });
+});

--- a/packages/smithy/src/services/agent-registry.bun.test.ts
+++ b/packages/smithy/src/services/agent-registry.bun.test.ts
@@ -14,6 +14,8 @@ import {
   type AgentRegistry,
   generateAgentChannelName,
   parseAgentChannelName,
+  isAgentDisabled,
+  isAgentEnabled,
 } from './agent-registry.js';
 import {
   type AgentEntity,
@@ -693,5 +695,34 @@ describe('AgentRegistry', () => {
         registry.ensureAgentChannel('non-existent-id' as EntityId)
       ).rejects.toThrow('Agent not found');
     });
+  });
+});
+
+describe('isAgentDisabled / isAgentEnabled', () => {
+  const baseAgent = {
+    id: 'el-test',
+    type: 'entity' as const,
+    createdAt: '2026-04-29T00:00:00Z',
+    updatedAt: '2026-04-29T00:00:00Z',
+    createdBy: 'el-0000',
+    tags: [],
+    metadata: { agent: { agentRole: 'worker' as const, workerMode: 'ephemeral' as const, sessionStatus: 'idle' as const } },
+  };
+
+  test('returns false when disabled is undefined', () => {
+    expect(isAgentDisabled(baseAgent as never)).toBe(false);
+    expect(isAgentEnabled(baseAgent as never)).toBe(true);
+  });
+
+  test('returns true when disabled is true', () => {
+    const disabled = { ...baseAgent, metadata: { agent: { ...baseAgent.metadata.agent, disabled: true } } };
+    expect(isAgentDisabled(disabled as never)).toBe(true);
+    expect(isAgentEnabled(disabled as never)).toBe(false);
+  });
+
+  test('returns false when disabled is explicitly false', () => {
+    const enabled = { ...baseAgent, metadata: { agent: { ...baseAgent.metadata.agent, disabled: false } } };
+    expect(isAgentDisabled(enabled as never)).toBe(false);
+    expect(isAgentEnabled(enabled as never)).toBe(true);
   });
 });

--- a/packages/smithy/src/services/agent-registry.ts
+++ b/packages/smithy/src/services/agent-registry.ts
@@ -470,7 +470,7 @@ export class AgentRegistryImpl implements AgentRegistry {
     const directors = await this.getDirectors();
     const running = directors.filter(d => {
       const meta = getAgentMetadata(d);
-      return meta?.sessionStatus === 'running';
+      return meta?.sessionStatus === 'running' && !isAgentDisabled(d);
     });
     if (preferredId) {
       const preferred = running.find(d => d.id === asElementId(preferredId));

--- a/packages/smithy/src/services/agent-registry.ts
+++ b/packages/smithy/src/services/agent-registry.ts
@@ -43,6 +43,16 @@ import {
 export type { AgentEntity };
 export { isAgentEntity, getAgentMetadata };
 
+/** Returns true if the agent is disabled (parked from dispatch and scheduling). */
+export function isAgentDisabled(agent: AgentEntity): boolean {
+  return getAgentMetadata(agent)?.disabled === true;
+}
+
+/** Returns true if the agent is not disabled. Inverse of isAgentDisabled. */
+export function isAgentEnabled(agent: AgentEntity): boolean {
+  return !isAgentDisabled(agent);
+}
+
 // ============================================================================
 // Constants
 // ============================================================================

--- a/packages/smithy/src/services/dispatch-daemon.bun.test.ts
+++ b/packages/smithy/src/services/dispatch-daemon.bun.test.ts
@@ -6395,4 +6395,44 @@ describe('assignTaskToWorker - per-director targetBranch propagation', () => {
     const opts = lastCallArgs[0];
     expect(opts.baseBranch).toBe('staging');
   });
+
+  describe('disabled agents', () => {
+    test('does not dispatch to a disabled worker when it is the only candidate', async () => {
+      // Register only a disabled worker. No enabled worker exists.
+      const disabledWorker = await createTestWorker('disabled-worker');
+      await agentRegistry.updateAgentMetadata(
+        disabledWorker.id as unknown as EntityId,
+        { disabled: true } as never
+      );
+
+      // Create a task that would normally be picked up.
+      await createTestTask('Task that must not go to disabled worker');
+
+      // Run the poll. With the filter in place, processed should be 0.
+      // Without the filter, it would be 1 (disabled worker gets the task).
+      const result = await daemon.pollWorkerAvailability();
+
+      expect(result.processed).toBe(0);
+    });
+
+    test('dispatches to enabled worker when disabled worker is also registered', async () => {
+      const enabledWorker = await createTestWorker('enabled-worker');
+      const disabledWorker = await createTestWorker('disabled-worker');
+      await agentRegistry.updateAgentMetadata(
+        disabledWorker.id as unknown as EntityId,
+        { disabled: true } as never
+      );
+
+      await createTestTask('Task for enabled worker only');
+
+      const result = await daemon.pollWorkerAvailability();
+
+      expect(result.processed).toBe(1);
+      // Confirm the disabled worker's id never appeared in startSession calls.
+      const startSessionCalls = (sessionManager.startSession as ReturnType<typeof mock>).mock.calls;
+      const assignedIds = startSessionCalls.map((c: unknown[]) => c[0] as string);
+      expect(assignedIds).toContain(enabledWorker.id as unknown as string);
+      expect(assignedIds).not.toContain(disabledWorker.id as unknown as string);
+    });
+  });
 });

--- a/packages/smithy/src/services/dispatch-daemon.ts
+++ b/packages/smithy/src/services/dispatch-daemon.ts
@@ -41,7 +41,7 @@ import { createLogger } from '../utils/logger.js';
 import { isRateLimitMessage, parseRateLimitResetTime, getFallbackResetTime } from '../utils/rate-limit-parser.js';
 
 import type { AgentRegistry, AgentEntity } from './agent-registry.js';
-import { getAgentMetadata } from './agent-registry.js';
+import { getAgentMetadata, isAgentDisabled } from './agent-registry.js';
 import type { SessionManager, SessionRecord } from '../runtime/session-manager.js';
 import type { DispatchService, DispatchOptions } from './dispatch-service.js';
 import type { WorktreeManager, CreateWorktreeResult } from '../git/worktree-manager.js';
@@ -876,6 +876,7 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       // defer task assignment so the next cycle's triage pass can handle them.
       const availableWorkers: AgentEntity[] = [];
       for (const worker of workers) {
+        if (isAgentDisabled(worker)) continue;
         const session = this.sessionManager.getActiveSession(asEntityId(worker.id));
         if (session) continue;
 
@@ -953,6 +954,7 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       for (const agent of agents) {
         try {
           const agentId = asEntityId(agent.id);
+          if (isAgentDisabled(agent)) continue;
           const meta = getAgentMetadata(agent);
           if (!meta) continue;
 
@@ -1083,9 +1085,10 @@ export class DispatchDaemonImpl implements DispatchDaemon {
     try {
       const stewards = await this.agentRegistry.getStewards();
 
-      // Find available stewards (no active session)
+      // Find available stewards (no active session, not disabled)
       const availableStewards: AgentEntity[] = [];
       for (const steward of stewards) {
+        if (isAgentDisabled(steward)) continue;
         const session = this.sessionManager.getActiveSession(asEntityId(steward.id));
         if (!session) {
           availableStewards.push(steward);
@@ -1220,6 +1223,7 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       const stewardsUsedThisCycle = new Set<string>();
 
       for (const worker of workers) {
+        if (isAgentDisabled(worker)) continue;
         const workerId = asEntityId(worker.id);
 
         // 2. Skip if worker has an active session
@@ -1324,6 +1328,7 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       });
 
       for (const steward of mergeStewards) {
+        if (isAgentDisabled(steward)) continue;
         const stewardId = asEntityId(steward.id);
 
         // Skip if steward has an active session
@@ -3434,6 +3439,7 @@ export class DispatchDaemonImpl implements DispatchDaemon {
     // cycle but may still have tasks assigned from the previous cycle.
     let recoverySteward: AgentEntity | undefined;
     for (const steward of stewards) {
+      if (isAgentDisabled(steward)) continue;
       const sid = asEntityId(steward.id);
       if (stewardsUsedThisCycle?.has(sid as string)) continue;
       const session = this.sessionManager.getActiveSession(sid);

--- a/packages/smithy/src/services/steward-scheduler.test.ts
+++ b/packages/smithy/src/services/steward-scheduler.test.ts
@@ -38,13 +38,15 @@ function createMockAgentEntity(
   id: string,
   name: string,
   focus: 'merge' | 'docs' | 'recovery' | 'custom',
-  triggers: StewardTrigger[] = []
+  triggers: StewardTrigger[] = [],
+  disabled?: boolean
 ): AgentEntity {
   const metadata: StewardMetadata = {
     agentRole: 'steward',
     stewardFocus: focus,
     triggers,
     sessionStatus: 'idle',
+    ...(disabled !== undefined ? { disabled } : {}),
   };
 
   return {
@@ -915,5 +917,55 @@ describe('StewardSchedulerImpl - logging', () => {
     );
 
     await scheduler.stop();
+  });
+});
+
+// ============================================================================
+// Disabled Steward Tests
+// ============================================================================
+
+describe('disabled stewards', () => {
+  it('registerSteward returns false and registers nothing when the steward is disabled', async () => {
+    const disabledSteward = createMockAgentEntity(
+      'steward-disabled',
+      'Disabled Steward',
+      'merge',
+      [{ type: 'cron', schedule: '*/5 * * * *' }],
+      true
+    );
+    const registry = createMockAgentRegistry([disabledSteward]);
+    const executor = createMockExecutor();
+    const scheduler = createStewardScheduler(registry, executor);
+
+    const ok = await scheduler.registerSteward('steward-disabled' as EntityId);
+    expect(ok).toBe(false);
+
+    // No cron jobs or event subscriptions should have been created.
+    const stats = scheduler.getStats();
+    expect(stats.registeredStewards).toBe(0);
+    expect(stats.activeCronJobs).toBe(0);
+    expect(stats.activeEventSubscriptions).toBe(0);
+  });
+
+  it('registerAllStewards skips disabled stewards in the count', async () => {
+    const enabledSteward = createMockAgentEntity(
+      's1',
+      's1',
+      'merge',
+      [{ type: 'cron', schedule: '*/5 * * * *' }]
+    );
+    const disabledSteward = createMockAgentEntity(
+      's2',
+      's2',
+      'docs',
+      [{ type: 'cron', schedule: '0 * * * *' }],
+      true
+    );
+    const registry = createMockAgentRegistry([enabledSteward, disabledSteward]);
+    const executor = createMockExecutor();
+    const scheduler = createStewardScheduler(registry, executor);
+
+    const registered = await scheduler.registerAllStewards();
+    expect(registered).toBe(1);
   });
 });

--- a/packages/smithy/src/services/steward-scheduler.ts
+++ b/packages/smithy/src/services/steward-scheduler.ts
@@ -41,7 +41,7 @@ import type { WorkflowPreset, AgentPermissionModel } from '@stoneforge/quarry';
 import { AUTO_ALLOWED_TOOLS, AUTO_ALLOWED_SF_COMMANDS } from '../permissions/types.js';
 import { detectTargetBranch } from '../git/merge.js';
 import type { AgentRegistry, AgentEntity } from './agent-registry.js';
-import { getAgentMetadata } from './agent-registry.js';
+import { getAgentMetadata, isAgentDisabled } from './agent-registry.js';
 import type { MergeStewardService } from './merge-steward-service.js';
 import type { DocsStewardService } from './docs-steward-service.js';
 import type { RateLimitTracker } from './rate-limit-tracker.js';
@@ -591,6 +591,11 @@ export class StewardSchedulerImpl implements StewardScheduler {
 
     const metadata = getAgentMetadata(agent);
     if (!metadata || metadata.agentRole !== 'steward') {
+      return false;
+    }
+
+    if (isAgentDisabled(agent)) {
+      logger.debug(`Skipping disabled steward ${stewardId}`);
       return false;
     }
 

--- a/packages/smithy/src/types/agent.bun.test.ts
+++ b/packages/smithy/src/types/agent.bun.test.ts
@@ -2,7 +2,7 @@
  * Agent Types Tests
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, it, test, expect } from 'bun:test';
 import type {
   CronTrigger,
   EventTrigger,
@@ -154,6 +154,22 @@ describe('AgentMetadata type guards', () => {
     expect(isStewardMetadata(steward)).toBe(true);
     expect(isStewardMetadata(director)).toBe(false);
     expect(isStewardMetadata(worker)).toBe(false);
+  });
+});
+
+describe('disabled flag', () => {
+  it('accepts disabled: true on each role', () => {
+    const director: DirectorMetadata = { agentRole: 'director', sessionStatus: 'idle', disabled: true };
+    const worker: WorkerMetadata = { agentRole: 'worker', workerMode: 'ephemeral', sessionStatus: 'idle', disabled: true };
+    const steward: StewardMetadata = { agentRole: 'steward', stewardFocus: 'merge', sessionStatus: 'idle', disabled: true };
+    expect(director.disabled).toBe(true);
+    expect(worker.disabled).toBe(true);
+    expect(steward.disabled).toBe(true);
+  });
+
+  it('treats omitted disabled as enabled', () => {
+    const director: DirectorMetadata = { agentRole: 'director', sessionStatus: 'idle' };
+    expect(director.disabled).toBeUndefined();
   });
 });
 

--- a/packages/smithy/src/types/agent.ts
+++ b/packages/smithy/src/types/agent.ts
@@ -187,6 +187,8 @@ export interface BaseAgentMetadata {
   readonly model?: string;
   /** Custom executable path for the agent's provider CLI (e.g., '/usr/local/bin/claude'). If not set, uses provider default. */
   readonly executablePath?: string;
+  /** When true, this agent is parked and excluded from dispatch and scheduler triggers. Defaults to false (omitted). */
+  readonly disabled?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #58. Adds a `disabled` flag on agent metadata plus the matching CLI commands and UI controls so an agent can be parked (excluded from dispatch, pool selection, scheduler triggers, and the Start action) without being removed from the agent list. In-flight sessions are NOT terminated when an agent is disabled; only future work is blocked.

### Backend

- `disabled?: boolean` on `BaseAgentMetadata` (default omitted, treated as enabled).
- `isAgentDisabled` / `isAgentEnabled` helpers on the registry.
- `getAvailableDirector` skips disabled directors even when their session is `running`.
- `dispatch-daemon` skips disabled agents at all candidate-selection sites in `pollWorkerAvailability`, `pollInboxes`, `pollWorkflowTasks`, and `recoverOrphanedAssignments`. Attribution-only `getAgentMetadata` reads (task creator, director identity for branch propagation, fallback chain resolution) are deliberately not filtered.
- `steward-scheduler.registerSteward` returns `false` and registers no triggers for disabled stewards. `registerAllStewards` inherits the filter through the existing call chain.
- `PATCH /api/agents/:id` accepts `disabled?: boolean`. Toggling on a steward triggers an immediate scheduler register/unregister so behavior changes without an orchestrator restart.

### CLI

- `sf agent disable <id>` and `sf agent enable <id>` flip the flag through `updateAgentMetadata`. Enable deletes the property so the absent-means-enabled contract holds in the JSON-serialised metadata.
- `sf agent start <id>` refuses with `Agent <id> is disabled. Run 'sf agent enable <id>' first to bring it back online.` and exits with `ExitCode.VALIDATION`.
- `sf agent list` appends `(disabled)` to the status column for affected agents (table output only; JSON serialisation is unchanged because the field passes through with the metadata).

### Web UI (smithy-web)

- `useToggleAgentDisabled` hook (mirrors `useChangeAgentTriggers`).
- `AgentCard`: card dims to 60% opacity and shows a yellow `Disabled` pill in the header when set; menu item toggles between `Disable agent` and `Enable agent` (with `Power` / `PowerOff` icons); Start button is hidden while disabled (the badge plus the menu item surface the state and the action).
- `BaseAgentMetadata.disabled` propagated through the web types.

### Out of scope

- Smithy-next (the scaffold-stage UI): no UI for disable yet. Worth a follow-up issue.
- Bulk operations (`sf agent disable --all --role steward`).
- A `--reason` annotation persisted as `disabledReason` on metadata.
- Auto-disable on repeated failure (separate concern: needs a circuit-breaker design).

## Test plan

- [x] `cd packages/smithy && bun test src` — 1559 pass, 19 skip, 0 fail.
- [x] `NODE_ENV=development npx turbo run typecheck` — 16/16 packages.
- [x] `NODE_ENV=development pnpm build` — 13/13 packages.
- [x] Manual CLI: `sf agent disable <id>` then `sf agent list` shows `(disabled)`; `sf agent start` refuses with the hinted command; `sf agent enable` clears the marker and `sf agent start` works again.
- [x] Manual UI: AgentCard menu Disable/Enable round-trips; the `Disabled` pill, dimmed card, and hidden Start button appear and disappear correctly; toggling a steward live updates the scheduler without `sf serve smithy` restart.
- [x] Behavioural unit tests for the disable/enable round-trip via `api.updateAgentMetadata`, the registry filter on `getAvailableDirector`, the dispatch-daemon worker filter, the start-handler refusal, the list marker, and the steward-scheduler skip path. All colocated as `*.bun.test.ts`.

## Notes for reviewers

- The change to `OrchestratorAPI.updateAgentMetadata` (private to public on the impl class plus added to the interface) is required because the new CLI handlers and PATCH route call it externally. The method body is unchanged.
- The `disabled` field is intentionally separate from `sessionStatus`: `sessionStatus` models in-flight session lifecycle, while `disabled` is a property of the agent itself. A disabled agent can still have `sessionStatus: 'running'` from a session that started before it was disabled; that session is allowed to finish.