### PR TITLE
feat(smithy,smithy-web): dispatch stuck-queue warning (#59)

### DIFF
--- a/.changeset/dispatch-stuck-warning.md
+++ b/.changeset/dispatch-stuck-warning.md
@@ -1,0 +1,12 @@
+---
+"@stoneforge/smithy": minor
+---
+
+Surface a dispatch-stuck warning when ready unassigned tasks have no available workers to take them.
+
+- New `getDispatchHealth()` method on `DispatchDaemon` returning `{ readyUnassignedTasks, availableWorkers, stuck, hasStuckQueue, computedAt }`. A worker is "available" when it is registered, not disabled, and not terminated. At-capacity workers do not count as stuck (the queue is busy, not stuck).
+- Per-tick CLI warn (rate-limited to once per 20 ticks, configurable via `DispatchDaemonConfig.stuckWarnTickInterval`): `[dispatch] N task(s) ready, no available workers...`. Re-warns immediately when the queue clears and re-stuckens.
+- `GET /api/daemon/status` includes a `health` field with the snapshot.
+- New smithy-web `DispatchHealthBanner` shown on the agents and workspaces pages when the queue is stuck. Dismissible per page-load.
+
+Closes #59. The pool-routing observation in #59 is filed separately.

--- a/apps/smithy-web/src/api/hooks/useDaemon.ts
+++ b/apps/smithy-web/src/api/hooks/useDaemon.ts
@@ -5,6 +5,7 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { DispatchHealth } from '../types';
 
 // ============================================================================
 // Types
@@ -28,6 +29,7 @@ export interface DaemonStatusResponse {
     limits: Array<{ executable: string; resetsAt: string }>;
     soonestReset?: string;
   };
+  health?: DispatchHealth;
 }
 
 export interface DaemonStartResponse {
@@ -85,7 +87,7 @@ export function useDaemonStatus() {
   return useQuery<DaemonStatusResponse, Error>({
     queryKey: ['daemon-status'],
     queryFn: () => fetchApi<DaemonStatusResponse>('/daemon/status'),
-    refetchInterval: 10000, // Poll every 10 seconds
+    refetchInterval: 5000, // Poll every 5 seconds
   });
 }
 

--- a/apps/smithy-web/src/api/types.ts
+++ b/apps/smithy-web/src/api/types.ts
@@ -623,6 +623,18 @@ export interface ApprovalRequestResponse {
 }
 
 // ============================================================================
+// Daemon / Dispatch Types
+// ============================================================================
+
+export interface DispatchHealth {
+  readyUnassignedTasks: number;
+  availableWorkers: number;
+  stuck: boolean;
+  hasStuckQueue: boolean;
+  computedAt: string;
+}
+
+// ============================================================================
 // Provider Metrics Types
 // ============================================================================
 

--- a/apps/smithy-web/src/components/dispatch/DispatchHealthBanner.tsx
+++ b/apps/smithy-web/src/components/dispatch/DispatchHealthBanner.tsx
@@ -2,7 +2,12 @@ import { useState } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
 import { useDaemonStatus } from '../../api/hooks/useDaemon';
 
-export function DispatchHealthBanner() {
+interface DispatchHealthBannerProps {
+  /** Optional layout classes applied to the outer banner element. Lets each mount site control its own page-specific padding without leaving an empty wrapper when the banner self-hides. */
+  className?: string;
+}
+
+export function DispatchHealthBanner({ className }: DispatchHealthBannerProps = {}) {
   const { data } = useDaemonStatus();
   const [dismissed, setDismissed] = useState(false);
 
@@ -11,9 +16,11 @@ export function DispatchHealthBanner() {
 
   const { readyUnassignedTasks } = data.health;
 
+  const baseClasses = 'mb-4 flex items-start gap-3 px-4 py-3 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-300 dark:border-amber-700 text-amber-900 dark:text-amber-100';
+
   return (
     <div
-      className="mb-4 flex items-start gap-3 px-4 py-3 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-300 dark:border-amber-700 text-amber-900 dark:text-amber-100"
+      className={className ? `${className} ${baseClasses}` : baseClasses}
       data-testid="dispatch-health-banner"
       role="alert"
     >

--- a/apps/smithy-web/src/components/dispatch/DispatchHealthBanner.tsx
+++ b/apps/smithy-web/src/components/dispatch/DispatchHealthBanner.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import { useDaemonStatus } from '../../api/hooks/useDaemon';
+
+export function DispatchHealthBanner() {
+  const { data } = useDaemonStatus();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+  if (!data?.health?.hasStuckQueue) return null;
+
+  const { readyUnassignedTasks } = data.health;
+
+  return (
+    <div
+      className="mb-4 flex items-start gap-3 px-4 py-3 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-300 dark:border-amber-700 text-amber-900 dark:text-amber-100"
+      data-testid="dispatch-health-banner"
+      role="alert"
+    >
+      <AlertTriangle className="w-5 h-5 mt-0.5 shrink-0" />
+      <div className="flex-1 min-w-0 text-sm">
+        <div className="font-medium">Dispatch is stuck.</div>
+        <div className="mt-1">
+          {readyUnassignedTasks} task(s) ready, no available workers. Register or enable a worker to start dispatching.
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        className="p-1 rounded hover:bg-amber-100 dark:hover:bg-amber-900/50 transition-colors"
+        aria-label="Dismiss"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}

--- a/apps/smithy-web/src/routes/agents/index.tsx
+++ b/apps/smithy-web/src/routes/agents/index.tsx
@@ -17,6 +17,7 @@ import { AgentCard, CreateAgentDialog, DeleteAgentDialog, RenameAgentDialog, Sta
 import { PoolCard, CreatePoolDialog, EditPoolDialog } from '../../components/pool';
 import { AgentWorkspaceGraph } from '../../components/agent-graph';
 import type { Agent, SessionStatus, AgentRole, StewardFocus } from '../../api/types';
+import { DispatchHealthBanner } from '../../components/dispatch/DispatchHealthBanner';
 
 type TabValue = 'agents' | 'stewards' | 'pools' | 'graph';
 
@@ -428,6 +429,9 @@ export function AgentsPage() {
           </button>
         </nav>
       </div>
+
+      {/* Dispatch health banner */}
+      <DispatchHealthBanner />
 
       {/* Content */}
       {currentTab === 'graph' ? (

--- a/apps/smithy-web/src/routes/workspaces/index.tsx
+++ b/apps/smithy-web/src/routes/workspaces/index.tsx
@@ -28,6 +28,7 @@ import {
   type LayoutPreset,
 } from '../../components/workspace';
 import { useAgent, useResumeAgentSession } from '../../api/hooks/useAgents';
+import { DispatchHealthBanner } from '../../components/dispatch/DispatchHealthBanner';
 
 /** Layout preset configuration */
 const layoutPresets: { id: LayoutPreset; icon: typeof Square; label: string }[] = [
@@ -329,6 +330,11 @@ export function WorkspacesPage() {
             </kbd>
           </button>
         </div>
+      </div>
+
+      {/* Dispatch health banner */}
+      <div className="px-6 pt-4">
+        <DispatchHealthBanner />
       </div>
 
       {/* Main content area */}

--- a/apps/smithy-web/src/routes/workspaces/index.tsx
+++ b/apps/smithy-web/src/routes/workspaces/index.tsx
@@ -333,9 +333,7 @@ export function WorkspacesPage() {
       </div>
 
       {/* Dispatch health banner */}
-      <div className="px-6 pt-4">
-        <DispatchHealthBanner />
-      </div>
+      <DispatchHealthBanner className="mx-6 mt-4" />
 
       {/* Main content area */}
       <div className="flex-1 min-h-0 p-4 overflow-hidden">

--- a/packages/smithy/src/server/routes/daemon.test.ts
+++ b/packages/smithy/src/server/routes/daemon.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Daemon Routes Tests — GET /api/daemon/status health field
+ *
+ * Tests that the status endpoint includes dispatch health when available,
+ * omits it when the daemon is not configured, and degrades gracefully when
+ * getDispatchHealth() throws.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Services } from '../services.js';
+import { createDaemonRoutes } from './daemon.js';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+function createMockServices(opts: { withDaemon?: boolean; healthThrows?: boolean } = {}) {
+  const dispatchDaemon =
+    opts.withDaemon === false
+      ? undefined
+      : {
+          isRunning: vi.fn().mockReturnValue(true),
+          getConfig: vi.fn().mockReturnValue({ pollIntervalMs: 500 }),
+          getRateLimitStatus: vi.fn().mockReturnValue({ active: false }),
+          getDispatchHealth: opts.healthThrows
+            ? vi.fn().mockRejectedValue(new Error('db unreachable'))
+            : vi.fn().mockResolvedValue({
+                readyUnassignedTasks: 3,
+                availableWorkers: 0,
+                stuck: true,
+                hasStuckQueue: true,
+                computedAt: '2026-05-03T00:00:00.000Z',
+              }),
+        };
+
+  const services = { dispatchDaemon } as unknown as Services;
+  return { services, dispatchDaemon };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('GET /api/daemon/status — health', () => {
+  it('includes the health snapshot when the daemon is available', async () => {
+    const { services } = createMockServices();
+    const app = createDaemonRoutes(services);
+    const res = await app.request('/api/daemon/status');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.health.hasStuckQueue).toBe(true);
+    expect(body.health.readyUnassignedTasks).toBe(3);
+    expect(body.health.availableWorkers).toBe(0);
+  });
+
+  it('omits the health field when the daemon is unavailable', async () => {
+    const { services } = createMockServices({ withDaemon: false });
+    const app = createDaemonRoutes(services);
+    const res = await app.request('/api/daemon/status');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.available).toBe(false);
+    expect(body.health).toBeUndefined();
+  });
+
+  it('still returns 200 with isRunning when getDispatchHealth throws', async () => {
+    const { services } = createMockServices({ healthThrows: true });
+    const app = createDaemonRoutes(services);
+    const res = await app.request('/api/daemon/status');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.isRunning).toBe(true);
+    expect(body.health).toBeUndefined();
+  });
+});

--- a/packages/smithy/src/server/routes/daemon.ts
+++ b/packages/smithy/src/server/routes/daemon.ts
@@ -30,7 +30,7 @@ export function createDaemonRoutes(services: Services) {
   const app = new Hono();
 
   // GET /api/daemon/status
-  app.get('/api/daemon/status', (c) => {
+  app.get('/api/daemon/status', async (c) => {
     if (!dispatchDaemon) {
       return c.json({
         isRunning: false,
@@ -42,6 +42,14 @@ export function createDaemonRoutes(services: Services) {
 
     const config = dispatchDaemon.getConfig();
     const rateLimitStatus = dispatchDaemon.getRateLimitStatus();
+
+    let health: import('../../services/dispatch-daemon.js').DispatchHealth | undefined;
+    try {
+      health = await dispatchDaemon.getDispatchHealth();
+    } catch (err) {
+      logger.warn('Failed to compute dispatch health for /api/daemon/status:', err);
+    }
+
     return c.json({
       isRunning: dispatchDaemon.isRunning(),
       available: true,
@@ -55,6 +63,7 @@ export function createDaemonRoutes(services: Services) {
         directorInboxForwardingEnabled: config.directorInboxForwardingEnabled,
       },
       rateLimit: rateLimitStatus,
+      health,
     });
   });
 

--- a/packages/smithy/src/services/dispatch-daemon.bun.test.ts
+++ b/packages/smithy/src/services/dispatch-daemon.bun.test.ts
@@ -6587,11 +6587,12 @@ describe('getDispatchHealth', () => {
   });
 });
 
-describe('stuck-queue tick warning', () => {
-  test('emits a warn log on tick when the queue is stuck', async () => {
+describe('stuck-queue transition logging', () => {
+  test('emits a STUCK warn on the healthy → stuck transition, then stays silent on subsequent ticks', async () => {
     const warnSpy = mock((..._args: unknown[]) => {});
+    const infoSpy = mock((..._args: unknown[]) => {});
     const harness = await setupDaemonHarness({
-      configOverrides: { logger: { warn: warnSpy } },
+      configOverrides: { logger: { warn: warnSpy, info: infoSpy } },
     });
     try {
       const task = await createTask({
@@ -6602,10 +6603,44 @@ describe('stuck-queue tick warning', () => {
       await harness.api.create(task as unknown as Record<string, unknown> & { createdBy: EntityId });
       // No workers registered; queue is stuck.
       await harness.daemon.tick();
-      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
       const message = warnSpy.mock.calls[0][0] as string;
+      expect(message).toContain('STUCK');
       expect(message).toContain('1 task(s) ready');
       expect(message).toContain('no available workers');
+
+      // Subsequent stuck ticks must NOT spam the log (transition-only model).
+      await harness.daemon.tick();
+      await harness.daemon.tick();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test('emits a RESUMED info on the stuck → healthy transition', async () => {
+    const warnSpy = mock((..._args: unknown[]) => {});
+    const infoSpy = mock((..._args: unknown[]) => {});
+    const harness = await setupDaemonHarness({
+      configOverrides: { logger: { warn: warnSpy, info: infoSpy } },
+    });
+    try {
+      const task = await createTask({
+        title: 'x',
+        createdBy: harness.systemEntity,
+        status: TaskStatus.OPEN,
+      });
+      await harness.api.create(task as unknown as Record<string, unknown> & { createdBy: EntityId });
+      // First tick: queue is stuck (no workers). Triggers STUCK warn.
+      await harness.daemon.tick();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      // Register a worker; on next tick the queue is healthy. Triggers RESUMED info.
+      await harness.registry.registerWorker({ name: 'w1', workerMode: 'ephemeral', createdBy: harness.systemEntity, maxConcurrentTasks: 1 });
+      await harness.daemon.tick();
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      const infoMessage = infoSpy.mock.calls[0][0] as string;
+      expect(infoMessage).toContain('RESUMED');
     } finally {
       await harness.dispose();
     }

--- a/packages/smithy/src/services/dispatch-daemon.bun.test.ts
+++ b/packages/smithy/src/services/dispatch-daemon.bun.test.ts
@@ -6436,3 +6436,152 @@ describe('assignTaskToWorker - per-director targetBranch propagation', () => {
     });
   });
 });
+
+// ============================================================================
+// getDispatchHealth harness + tests
+// ============================================================================
+
+interface DaemonHarness {
+  api: QuarryAPI;
+  registry: AgentRegistry;
+  daemon: DispatchDaemon;
+  systemEntity: EntityId;
+  dispose(): Promise<void>;
+}
+
+async function setupDaemonHarness(): Promise<DaemonHarness> {
+  const dbPath = `/tmp/dispatch-health-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+  const storage = createStorage({ path: dbPath, create: true });
+  initializeSchema(storage);
+
+  const api = createQuarryAPI(storage);
+  const inboxService = createInboxService(storage);
+  const registry = createAgentRegistry(api);
+  const taskAssignment = createTaskAssignmentService(api);
+  const dispatchService = createDispatchService(api, taskAssignment, registry);
+  const sessionManager = createMockSessionManager();
+  const worktreeManager = createMockWorktreeManager();
+  const stewardScheduler = createMockStewardScheduler();
+
+  const { createEntity, EntityTypeValue } = await import('@stoneforge/core');
+  const systemRaw = await createEntity({
+    name: 'health-test-system',
+    entityType: EntityTypeValue.SYSTEM,
+    createdBy: 'system:test' as EntityId,
+  });
+  const saved = await api.create(systemRaw as unknown as Record<string, unknown> & { createdBy: EntityId });
+  const systemEntity = saved.id as unknown as EntityId;
+
+  const config: DispatchDaemonConfig = {
+    ensureTargetBranchExists: mockEnsureTargetBranchExists,
+    pollIntervalMs: 100,
+    workerAvailabilityPollEnabled: false,
+    inboxPollEnabled: false,
+    stewardTriggerPollEnabled: false,
+    workflowTaskPollEnabled: false,
+  };
+
+  const daemon = createDispatchDaemon(
+    api,
+    registry,
+    sessionManager,
+    dispatchService,
+    worktreeManager,
+    taskAssignment,
+    stewardScheduler,
+    inboxService,
+    config
+  );
+
+  return {
+    api,
+    registry,
+    daemon,
+    systemEntity,
+    async dispose() {
+      await daemon.stop();
+      if (fs.existsSync(dbPath)) {
+        fs.unlinkSync(dbPath);
+      }
+    },
+  };
+}
+
+describe('getDispatchHealth', () => {
+  test('reports stuck=false when there are no ready tasks', async () => {
+    const harness = await setupDaemonHarness();
+    try {
+      const health = await harness.daemon.getDispatchHealth();
+      expect(health.readyUnassignedTasks).toBe(0);
+      expect(health.availableWorkers).toBe(0);
+      expect(health.stuck).toBe(false);
+      expect(typeof health.computedAt).toBe('string');
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test('reports stuck=true when ready unassigned tasks exist and no workers are registered', async () => {
+    const harness = await setupDaemonHarness();
+    try {
+      const task = await createTask({
+        title: 'do the thing',
+        createdBy: harness.systemEntity,
+        status: TaskStatus.OPEN,
+      });
+      await harness.api.create(task as unknown as Record<string, unknown> & { createdBy: EntityId });
+      const health = await harness.daemon.getDispatchHealth();
+      expect(health.readyUnassignedTasks).toBe(1);
+      expect(health.availableWorkers).toBe(0);
+      expect(health.stuck).toBe(true);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test('reports stuck=false when ready unassigned tasks have at least one available worker', async () => {
+    const harness = await setupDaemonHarness();
+    try {
+      const task = await createTask({
+        title: 'do the thing',
+        createdBy: harness.systemEntity,
+        status: TaskStatus.OPEN,
+      });
+      await harness.api.create(task as unknown as Record<string, unknown> & { createdBy: EntityId });
+      await harness.registry.registerWorker({
+        name: 'w1',
+        workerMode: 'ephemeral',
+        createdBy: harness.systemEntity,
+      });
+      const health = await harness.daemon.getDispatchHealth();
+      expect(health.readyUnassignedTasks).toBe(1);
+      expect(health.availableWorkers).toBe(1);
+      expect(health.stuck).toBe(false);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test('treats disabled workers as unavailable for stuck-queue detection', async () => {
+    const harness = await setupDaemonHarness();
+    try {
+      const task = await createTask({
+        title: 'do the thing',
+        createdBy: harness.systemEntity,
+        status: TaskStatus.OPEN,
+      });
+      await harness.api.create(task as unknown as Record<string, unknown> & { createdBy: EntityId });
+      const w = await harness.registry.registerWorker({
+        name: 'w1',
+        workerMode: 'ephemeral',
+        createdBy: harness.systemEntity,
+      });
+      await harness.registry.updateAgentMetadata(w.id, { disabled: true });
+      const health = await harness.daemon.getDispatchHealth();
+      expect(health.availableWorkers).toBe(0);
+      expect(health.stuck).toBe(true);
+    } finally {
+      await harness.dispose();
+    }
+  });
+});

--- a/packages/smithy/src/services/dispatch-daemon.bun.test.ts
+++ b/packages/smithy/src/services/dispatch-daemon.bun.test.ts
@@ -6449,7 +6449,7 @@ interface DaemonHarness {
   dispose(): Promise<void>;
 }
 
-async function setupDaemonHarness(): Promise<DaemonHarness> {
+async function setupDaemonHarness(opts?: { configOverrides?: Partial<DispatchDaemonConfig> }): Promise<DaemonHarness> {
   const dbPath = `/tmp/dispatch-health-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
   const storage = createStorage({ path: dbPath, create: true });
   initializeSchema(storage);
@@ -6479,6 +6479,7 @@ async function setupDaemonHarness(): Promise<DaemonHarness> {
     inboxPollEnabled: false,
     stewardTriggerPollEnabled: false,
     workflowTaskPollEnabled: false,
+    ...opts?.configOverrides,
   };
 
   const daemon = createDispatchDaemon(
@@ -6580,6 +6581,31 @@ describe('getDispatchHealth', () => {
       const health = await harness.daemon.getDispatchHealth();
       expect(health.availableWorkers).toBe(0);
       expect(health.stuck).toBe(true);
+    } finally {
+      await harness.dispose();
+    }
+  });
+});
+
+describe('stuck-queue tick warning', () => {
+  test('emits a warn log on tick when the queue is stuck', async () => {
+    const warnSpy = mock((..._args: unknown[]) => {});
+    const harness = await setupDaemonHarness({
+      configOverrides: { logger: { warn: warnSpy } },
+    });
+    try {
+      const task = await createTask({
+        title: 'x',
+        createdBy: harness.systemEntity,
+        status: TaskStatus.OPEN,
+      });
+      await harness.api.create(task as unknown as Record<string, unknown> & { createdBy: EntityId });
+      // No workers registered; queue is stuck.
+      await harness.daemon.tick();
+      expect(warnSpy).toHaveBeenCalled();
+      const message = warnSpy.mock.calls[0][0] as string;
+      expect(message).toContain('1 task(s) ready');
+      expect(message).toContain('no available workers');
     } finally {
       await harness.dispose();
     }

--- a/packages/smithy/src/services/dispatch-daemon.ts
+++ b/packages/smithy/src/services/dispatch-daemon.ts
@@ -294,6 +294,32 @@ export interface DispatchDaemonConfig {
    * Useful for testing without triggering real git remote operations.
    */
   readonly ensureTargetBranchExists?: (projectRoot: string, branchName: string) => Promise<void>;
+
+  /** Optional logger override. Defaults to the module-level dispatch-daemon logger. Used for testability. */
+  readonly logger?: { warn: (...args: unknown[]) => void };
+
+  /** Number of ticks between repeated stuck-queue warnings. Default 20. */
+  readonly stuckWarnTickInterval?: number;
+}
+
+/**
+ * Snapshot of the dispatch worker queue's stuck state.
+ * Computed on demand from the agent registry and ready-task list.
+ * A queue is "stuck" when there are unassigned ready tasks but no worker
+ * could take them (registered, not disabled, not terminated). At-capacity
+ * workers do NOT count: the queue is busy, not stuck.
+ */
+export interface DispatchHealth {
+  /** Count of ready tasks (api.ready result) that have no assignee. */
+  readonly readyUnassignedTasks: number;
+  /** Count of workers eligible to take new work: registered, not disabled, not terminated. */
+  readonly availableWorkers: number;
+  /** True iff readyUnassignedTasks > 0 && availableWorkers === 0. */
+  readonly stuck: boolean;
+  /** Convenience alias for stuck, matching the field name surfaced in the HTTP and UI layers. */
+  readonly hasStuckQueue: boolean;
+  /** Timestamp the snapshot was computed (ISO 8601). */
+  readonly computedAt: string;
 }
 
 /**
@@ -338,6 +364,8 @@ interface NormalizedConfig {
   directorInboxForwardingEnabled: boolean;
   directorInboxIdleThresholdMs: number;
   ensureTargetBranchExists: (projectRoot: string, branchName: string) => Promise<void>;
+  logger?: { warn: (...args: unknown[]) => void };
+  stuckWarnTickInterval: number;
 }
 
 // ============================================================================
@@ -478,13 +506,23 @@ export interface DispatchDaemon {
   /**
    * Gets the current configuration.
    */
-  getConfig(): Omit<Required<DispatchDaemonConfig>, 'onSessionStarted'> & { onSessionStarted?: OnSessionStartedCallback };
+  getConfig(): Omit<Required<DispatchDaemonConfig>, 'onSessionStarted' | 'logger'> & { onSessionStarted?: OnSessionStartedCallback; logger?: { warn: (...args: unknown[]) => void } };
 
   /**
    * Updates the configuration.
    * Takes effect on the next poll cycle.
    */
   updateConfig(config: Partial<DispatchDaemonConfig>): void;
+
+  // ----------------------------------------
+  // Health
+  // ----------------------------------------
+
+  /**
+   * Returns a snapshot of dispatch worker-queue health.
+   * Inexpensive (one ready-task query, one agent list query); safe to call from HTTP routes.
+   */
+  getDispatchHealth(): Promise<DispatchHealth>;
 
   // ----------------------------------------
   // Events
@@ -712,6 +750,34 @@ export class DispatchDaemonImpl implements DispatchDaemon {
 
   isRunning(): boolean {
     return this.running;
+  }
+
+  // ----------------------------------------
+  // Health
+  // ----------------------------------------
+
+  async getDispatchHealth(): Promise<DispatchHealth> {
+    const readyTasks = await this.api.ready({ includeEphemeral: true });
+    const readyUnassignedTasks = readyTasks.filter(t => !t.assignee).length;
+
+    const allAgents = await this.agentRegistry.listAgents();
+    const availableWorkers = allAgents.filter(a => {
+      const meta = getAgentMetadata(a);
+      if (!meta || meta.agentRole !== 'worker') return false;
+      if (isAgentDisabled(a)) return false;
+      if (meta.sessionStatus === 'terminated') return false;
+      return true;
+    }).length;
+
+    const stuck = readyUnassignedTasks > 0 && availableWorkers === 0;
+
+    return {
+      readyUnassignedTasks,
+      availableWorkers,
+      stuck,
+      hasStuckQueue: stuck,
+      computedAt: new Date().toISOString(),
+    };
   }
 
   // ----------------------------------------
@@ -1916,7 +1982,7 @@ export class DispatchDaemonImpl implements DispatchDaemon {
   // Configuration
   // ----------------------------------------
 
-  getConfig(): Omit<Required<DispatchDaemonConfig>, 'onSessionStarted'> & { onSessionStarted?: OnSessionStartedCallback } {
+  getConfig(): Omit<Required<DispatchDaemonConfig>, 'onSessionStarted' | 'logger'> & { onSessionStarted?: OnSessionStartedCallback; logger?: { warn: (...args: unknown[]) => void } } {
     return { ...this.config };
   }
 
@@ -2027,6 +2093,8 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       directorInboxForwardingEnabled: config?.directorInboxForwardingEnabled ?? true,
       directorInboxIdleThresholdMs: config?.directorInboxIdleThresholdMs ?? 120_000,
       ensureTargetBranchExists: config?.ensureTargetBranchExists ?? ensureTargetBranchExists,
+      logger: config?.logger,
+      stuckWarnTickInterval: config?.stuckWarnTickInterval ?? 20,
     };
   }
 

--- a/packages/smithy/src/services/dispatch-daemon.ts
+++ b/packages/smithy/src/services/dispatch-daemon.ts
@@ -524,6 +524,12 @@ export interface DispatchDaemon {
    */
   getDispatchHealth(): Promise<DispatchHealth>;
 
+  /**
+   * Manually triggers one complete poll cycle (same work as the interval-driven cycle).
+   * Useful for testing and for callers that want to force an immediate dispatch pass.
+   */
+  tick(): Promise<void>;
+
   // ----------------------------------------
   // Events
   // ----------------------------------------
@@ -613,6 +619,15 @@ export class DispatchDaemonImpl implements DispatchDaemon {
 
   /** TTL for emitted warning deduplication keys (5 minutes). */
   private static readonly WARNING_DEDUP_TTL_MS = 5 * 60 * 1000;
+
+  /**
+   * Ticks elapsed since the last stuck-queue warn was emitted.
+   * Initialized to POSITIVE_INFINITY so the first stuck tick warns immediately
+   * (Infinity + 1 is still Infinity, which is >= any interval).
+   * Reset to POSITIVE_INFINITY when the queue is healthy so re-stuckening
+   * warns immediately again.
+   */
+  private ticksSinceLastStuckWarn = Number.POSITIVE_INFINITY;
 
   constructor(
     api: QuarryAPI,
@@ -778,6 +793,35 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       hasStuckQueue: stuck,
       computedAt: new Date().toISOString(),
     };
+  }
+
+  async tick(): Promise<void> {
+    await this.runPollCycle();
+  }
+
+  private async maybeLogStuckQueueWarning(): Promise<void> {
+    const interval = this.config.stuckWarnTickInterval;
+    let health: DispatchHealth;
+    try {
+      health = await this.getDispatchHealth();
+    } catch {
+      // Health computation must never crash the tick loop.
+      return;
+    }
+
+    if (!health.stuck) {
+      this.ticksSinceLastStuckWarn = Number.POSITIVE_INFINITY;
+      return;
+    }
+
+    this.ticksSinceLastStuckWarn += 1;
+    if (this.ticksSinceLastStuckWarn < interval) return;
+
+    const log = this.config.logger ?? logger;
+    log.warn(
+      `[dispatch] ${health.readyUnassignedTasks} task(s) ready, no available workers. Register or enable a worker so dispatch can proceed.`
+    );
+    this.ticksSinceLastStuckWarn = 0;
   }
 
   // ----------------------------------------
@@ -2201,6 +2245,8 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       if (this.config.workflowAutoTransitionEnabled) {
         await this.pollWorkflowAutoTransition();
       }
+
+      await this.maybeLogStuckQueueWarning();
     } finally {
       this.polling = false;
     }

--- a/packages/smithy/src/services/dispatch-daemon.ts
+++ b/packages/smithy/src/services/dispatch-daemon.ts
@@ -296,10 +296,7 @@ export interface DispatchDaemonConfig {
   readonly ensureTargetBranchExists?: (projectRoot: string, branchName: string) => Promise<void>;
 
   /** Optional logger override. Defaults to the module-level dispatch-daemon logger. Used for testability. */
-  readonly logger?: { warn: (...args: unknown[]) => void };
-
-  /** Number of ticks between repeated stuck-queue warnings. Default 20. */
-  readonly stuckWarnTickInterval?: number;
+  readonly logger?: { warn: (...args: unknown[]) => void; info?: (...args: unknown[]) => void };
 }
 
 /**
@@ -364,8 +361,7 @@ interface NormalizedConfig {
   directorInboxForwardingEnabled: boolean;
   directorInboxIdleThresholdMs: number;
   ensureTargetBranchExists: (projectRoot: string, branchName: string) => Promise<void>;
-  logger?: { warn: (...args: unknown[]) => void };
-  stuckWarnTickInterval: number;
+  logger?: { warn: (...args: unknown[]) => void; info?: (...args: unknown[]) => void };
 }
 
 // ============================================================================
@@ -627,7 +623,8 @@ export class DispatchDaemonImpl implements DispatchDaemon {
    * Reset to POSITIVE_INFINITY when the queue is healthy so re-stuckening
    * warns immediately again.
    */
-  private ticksSinceLastStuckWarn = Number.POSITIVE_INFINITY;
+  /** Tracks the last reported stuck state so we log only on transitions, never on every tick. */
+  private lastReportedStuck = false;
 
   constructor(
     api: QuarryAPI,
@@ -799,8 +796,13 @@ export class DispatchDaemonImpl implements DispatchDaemon {
     await this.runPollCycle();
   }
 
+  /**
+   * Logs ONLY on stuck-queue state transitions, never repeats while the state holds.
+   * Healthy → Stuck: emits a single STUCK warn line.
+   * Stuck → Healthy: emits a single RESUMED info line.
+   * No periodic reminders, so a long-running stuck state does not spam logs.
+   */
   private async maybeLogStuckQueueWarning(): Promise<void> {
-    const interval = this.config.stuckWarnTickInterval;
     let health: DispatchHealth;
     try {
       health = await this.getDispatchHealth();
@@ -809,19 +811,20 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       return;
     }
 
-    if (!health.stuck) {
-      this.ticksSinceLastStuckWarn = Number.POSITIVE_INFINITY;
-      return;
+    if (health.stuck && !this.lastReportedStuck) {
+      const log = this.config.logger ?? logger;
+      log.warn(
+        `[dispatch] STUCK: ${health.readyUnassignedTasks} task(s) ready, no available workers. Register or enable a worker so dispatch can proceed.`
+      );
+      this.lastReportedStuck = true;
+    } else if (!health.stuck && this.lastReportedStuck) {
+      const log = this.config.logger ?? logger;
+      const info = log.info ?? log.warn;
+      info(
+        `[dispatch] RESUMED: ${health.availableWorkers} worker(s) available, dispatch flowing again.`
+      );
+      this.lastReportedStuck = false;
     }
-
-    this.ticksSinceLastStuckWarn += 1;
-    if (this.ticksSinceLastStuckWarn < interval) return;
-
-    const log = this.config.logger ?? logger;
-    log.warn(
-      `[dispatch] ${health.readyUnassignedTasks} task(s) ready, no available workers. Register or enable a worker so dispatch can proceed.`
-    );
-    this.ticksSinceLastStuckWarn = 0;
   }
 
   // ----------------------------------------
@@ -2138,7 +2141,6 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       directorInboxIdleThresholdMs: config?.directorInboxIdleThresholdMs ?? 120_000,
       ensureTargetBranchExists: config?.ensureTargetBranchExists ?? ensureTargetBranchExists,
       logger: config?.logger,
-      stuckWarnTickInterval: config?.stuckWarnTickInterval ?? 20,
     };
   }
 


### PR DESCRIPTION
## Summary

Closes #59. Detects and surfaces dispatch stuck-queue conditions when workers are unavailable.

- `DispatchDaemon.getDispatchHealth()` reports `readyUnassignedTasks`, `availableWorkers`, `stuck`. Stuck = ready unassigned > 0 AND no available workers (worker = `agentRole === 'worker'`, not disabled, session not terminated).
- Daemon logs a single `[dispatch] STUCK` line on the healthy→stuck transition and a single `[dispatch] RESUMED` on the way back. No periodic warns to keep noise out of busy logs.
- `GET /api/daemon/status` includes a `health` field (`hasStuckQueue`, `readyUnassignedTasks`, `availableWorkers`).
- `smithy-web` shows a dismissible amber banner on the agents and workspaces pages when the API reports a stuck queue, polling every 5s.

## Why this design

The original issue suggested either a startup-only line, periodic warns, or a `--require-agents` flag. After dogfooding, periodic warns drowned in heartbeats and a startup-only line missed the common case (worker dies mid-session). Transition logging gives one clear line at the moment something changes, and the banner gives a visible signal in the UI without being modal.

Pool-routing observation from the issue is filed separately as #94 to keep this PR scoped.

## Test plan

- [x] `bun test packages/smithy/src/services/dispatch-daemon.bun.test.ts` (4 detection + 2 transition cases)
- [x] `pnpm --filter @stoneforge/smithy test src/server/routes/daemon.test.ts` (3 vitest cases incl. throw path)
- [x] Workspace `turbo typecheck` clean
- [x] Manual: started `sf serve smithy` against a repo with ready tasks and no attached workers, observed STUCK log + amber banner; attached a worker, observed RESUMED log + banner cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)