### PR TITLE
fix(smithy): clearer error from `sf agent start`

### DIFF
--- a/.changeset/sf-agent-start-clarity.md
+++ b/.changeset/sf-agent-start-clarity.md
@@ -1,0 +1,10 @@
+---
+"@stoneforge/smithy": patch
+---
+
+fix: clearer error from `sf agent start` when headless invocation has no input source
+
+`sf agent start <id>` for a worker/steward in headless mode now refuses
+upfront when invoked without --prompt or --resume, with an explanation
+and the three fixes (--prompt, --resume, --mode interactive). Replaces
+the cryptic "Session exited before init" error users previously saw.

--- a/packages/smithy/src/cli/commands/agent.bun.test.ts
+++ b/packages/smithy/src/cli/commands/agent.bun.test.ts
@@ -482,4 +482,39 @@ describe('agent disable / enable behavioural', () => {
       rmSync(tmpRoot, { recursive: true, force: true });
     }
   });
+
+  test('start refuses headless invocation without --prompt or --resume', async () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'sf-start-validation-test-'));
+    const cwdBefore = process.cwd();
+    try {
+      mkdirSync(join(tmpRoot, '.stoneforge'), { recursive: true });
+      const dbPath = join(tmpRoot, '.stoneforge', 'stoneforge.db');
+      const tmpBackend = createStorage({ path: dbPath, create: true });
+      initializeSchema(tmpBackend);
+      const tmpApi = createOrchestratorAPI(tmpBackend);
+      const registered = await tmpApi.registerWorker({
+        name: 'naked-worker',
+        workerMode: 'ephemeral',
+        createdBy: CREATOR,
+      });
+
+      process.chdir(tmpRoot);
+      try {
+        const result = await agentStartCommand.handler!(
+          [registered.id as unknown as string],
+          { db: dbPath } as never
+        );
+        expect(result.exitCode).not.toBe(0);
+        const errMsg = String(result.error ?? '');
+        expect(errMsg).toContain('headless');
+        expect(errMsg).toContain('--prompt');
+        expect(errMsg).toContain('--resume');
+        expect(errMsg).toContain('--mode interactive');
+      } finally {
+        process.chdir(cwdBefore);
+      }
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/smithy/src/cli/commands/agent.ts
+++ b/packages/smithy/src/cli/commands/agent.ts
@@ -950,6 +950,30 @@ async function agentStartHandler(
       spawnMode = options.mode as 'headless' | 'interactive';
     }
 
+    // Resolve effective spawn mode using the same rule as
+    // SpawnerServiceImpl.determineSpawnMode: director → interactive,
+    // worker/steward → headless, unless explicitly overridden.
+    const effectiveMode: 'headless' | 'interactive' =
+      spawnMode ?? (agentRole === 'director' ? 'interactive' : 'headless');
+
+    if (effectiveMode === 'headless' && !options.prompt && !options.resume) {
+      return failure(
+        [
+          `Cannot start a headless ${agentRole} without an initial prompt.`,
+          `Headless agents read input via stdin; without --prompt or --resume the process exits immediately.`,
+          ``,
+          `Provide one of:`,
+          `  --prompt "..."           Initial instructions for the agent`,
+          `  --resume <session-id>    Resume a previous session`,
+          `  --mode interactive       Start as an interactive (PTY) session`,
+          ``,
+          `Note: in dispatch-driven workflows, the daemon spawns workers automatically when tasks are ready.`,
+          `Manual restart of ephemeral workers is usually unnecessary.`,
+        ].join('\n'),
+        ExitCode.VALIDATION
+      );
+    }
+
     // Spawn the agent
     const result = await spawner.spawn(id as EntityId, agentRole, {
       initialPrompt: options.prompt,
@@ -1040,6 +1064,8 @@ Options:
   --stream                 Stream agent output after starting
   --provider <name>        Override agent provider for this session
   --model <model>          Override model for this session
+
+For headless workers/stewards (default), one of --prompt, --resume, or --mode interactive is required.
 
 Examples:
   sf agent start el-abc123


### PR DESCRIPTION
## Summary

Closes #61.

`sf agent start <id>` for a worker defaults to headless mode, which feeds prompts via stdin. Without `--prompt` or `--resume` the spawned process has no input, exits immediately, and the user sees `Failed to start agent: Session exited before init`.

This PR makes that path explainable. `agentStartHandler` now refuses headless invocations with no input source up front and prints the cause plus the three fixes (`--prompt`, `--resume`, `--mode interactive`). The note also clarifies that dispatch-driven workflows respawn workers automatically.

A spawner-side enrichment of the `Session exited before init` message was considered as a backstop, but the headless path emits a synthetic exit code (0 or 1 derived from `resumeErrorDetected`) rather than the underlying child process exit, so enriching with that code produces misleading output for the exact case the issue is about. Tracked as a follow-up if a real exit-code propagation path is needed.

The dispatch daemon path is untouched: it always supplies an `initialPrompt` and never hits this case.

## Test plan

- [x] `bun test packages/smithy/src/cli/commands/agent.bun.test.ts` (new validation test + all pre-existing tests pass)
- [x] Workspace `turbo typecheck` clean
- [x] `pnpm build` clean
- [x] Manual: `sf agent start <worker-id>` with no flags prints the new validation error; `sf agent start <worker-id> --prompt "..."` proceeds to spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)