### PR TITLE
fix(smithy): strip CLAUDECODE from spawned-claude env (closes #103)

### DIFF
--- a/.changeset/strip-claudecode-from-spawn-env.md
+++ b/.changeset/strip-claudecode-from-spawn-env.md
@@ -1,0 +1,9 @@
+---
+"@stoneforge/smithy": patch
+---
+
+fix: strip CLAUDECODE from spawned-claude env to allow nested spawns
+
+When stoneforge runs from inside a Claude Code session (any user invoking `sf` from Claude Code's bash tool, or a director orchestrating workers from a Claude Code session), the spawned claude subprocess inherits `CLAUDECODE=1` from `process.env`. The previous explicit `CLAUDECODE: '1'` in the env spread re-asserted it. Modern claude versions read `CLAUDECODE` and refuse to start with "Claude Code cannot be launched inside another Claude Code session", which the spawner surfaced as the cryptic "Session exited before init".
+
+Strip `CLAUDECODE` from the env passed to both headless (SDK) and interactive (PTY) provider spawns. Stoneforge IS the parent; the spawned claude is a fresh top-level session, not nested.

--- a/packages/smithy/src/providers/claude/env.bun.test.ts
+++ b/packages/smithy/src/providers/claude/env.bun.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'bun:test';
+import { buildClaudeSpawnEnv } from './env.js';
+
+describe('buildClaudeSpawnEnv', () => {
+  it('strips CLAUDECODE from inherited env (parent is a Claude Code session)', () => {
+    const env = buildClaudeSpawnEnv({ CLAUDECODE: '1', PATH: '/usr/bin' });
+    expect(env.CLAUDECODE).toBeUndefined();
+    expect(env.PATH).toBe('/usr/bin');
+  });
+
+  it('strips CLAUDECODE from caller overrides too', () => {
+    const env = buildClaudeSpawnEnv(
+      { PATH: '/usr/bin' },
+      { overrides: { CLAUDECODE: '1', CUSTOM: 'value' } }
+    );
+    expect(env.CLAUDECODE).toBeUndefined();
+    expect(env.CUSTOM).toBe('value');
+    expect(env.PATH).toBe('/usr/bin');
+  });
+
+  it('preserves all other env vars', () => {
+    const env = buildClaudeSpawnEnv({
+      HOME: '/home/test',
+      PATH: '/usr/bin:/bin',
+      ANTHROPIC_API_KEY: 'sk-redacted',
+      USER: 'tester',
+    });
+    expect(env.HOME).toBe('/home/test');
+    expect(env.PATH).toBe('/usr/bin:/bin');
+    expect(env.ANTHROPIC_API_KEY).toBe('sk-redacted');
+    expect(env.USER).toBe('tester');
+  });
+
+  it('caller overrides take precedence over inherited env', () => {
+    const env = buildClaudeSpawnEnv(
+      { CUSTOM: 'inherited' },
+      { overrides: { CUSTOM: 'override' } }
+    );
+    expect(env.CUSTOM).toBe('override');
+  });
+
+  it('sets STONEFORGE_ROOT when provided', () => {
+    const env = buildClaudeSpawnEnv({}, { stoneforgeRoot: '/path/to/.stoneforge' });
+    expect(env.STONEFORGE_ROOT).toBe('/path/to/.stoneforge');
+  });
+
+  it('does not set STONEFORGE_ROOT when omitted', () => {
+    const env = buildClaudeSpawnEnv({});
+    expect(env.STONEFORGE_ROOT).toBeUndefined();
+  });
+
+  it('returns a fresh object each call (no mutation of inputs)', () => {
+    const base = { CLAUDECODE: '1', PATH: '/usr/bin' };
+    buildClaudeSpawnEnv(base);
+    expect(base.CLAUDECODE).toBe('1');
+    expect(base.PATH).toBe('/usr/bin');
+  });
+});

--- a/packages/smithy/src/providers/claude/env.ts
+++ b/packages/smithy/src/providers/claude/env.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared environment construction for Claude provider spawns.
+ *
+ * Both the headless (SDK) and interactive (PTY) providers construct the env
+ * passed to the spawned claude subprocess. The shape is the same across both,
+ * and one detail in particular is load-bearing: CLAUDECODE must be stripped.
+ *
+ * Why: modern versions of the claude binary read CLAUDECODE and refuse to
+ * start when it is set, with the error "Claude Code cannot be launched
+ * inside another Claude Code session." If stoneforge is invoked from inside
+ * an existing Claude Code session (any user running `sf` from Claude Code's
+ * bash tool, or a director orchestrating from within Claude Code), the
+ * inherited CLAUDECODE=1 triggers this guard and the spawn dies before init.
+ * The Anthropic SDK reports it as `Claude Code process exited with code 1`,
+ * which the spawner surfaces as the cryptic `Session exited before init`.
+ *
+ * Stoneforge IS the parent process; the spawned claude is a fresh top-level
+ * session, not nested. So CLAUDECODE has no business being set in the child.
+ */
+
+export interface ClaudeSpawnEnvOptions {
+  /** Override environment variables (caller-supplied; merged after process.env). */
+  readonly overrides?: Record<string, string>;
+  /** Stoneforge project root, exposed to the child as STONEFORGE_ROOT. */
+  readonly stoneforgeRoot?: string;
+}
+
+/**
+ * Build the environment for a spawned claude subprocess.
+ *
+ * Order of precedence (later wins):
+ * 1. process.env (inherited)
+ * 2. caller's `overrides`
+ *
+ * Then CLAUDECODE is unconditionally stripped (regardless of source), and
+ * STONEFORGE_ROOT is set if provided.
+ */
+export function buildClaudeSpawnEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  options: ClaudeSpawnEnvOptions = {}
+): Record<string, string> {
+  const env: Record<string, string> = {
+    ...(baseEnv as Record<string, string>),
+    ...options.overrides,
+  };
+  delete env.CLAUDECODE;
+  if (options.stoneforgeRoot) {
+    env.STONEFORGE_ROOT = options.stoneforgeRoot;
+  }
+  return env;
+}

--- a/packages/smithy/src/providers/claude/headless.bun.test.ts
+++ b/packages/smithy/src/providers/claude/headless.bun.test.ts
@@ -351,4 +351,50 @@ describe('ClaudeHeadlessProvider', () => {
       expect(provider.name).toBe('claude-headless');
     });
   });
+
+  describe('CLAUDECODE env handling', () => {
+    // Regression test for the nested-session refusal: if CLAUDECODE is set
+    // in the parent process env (e.g., stoneforge is invoked from inside
+    // an existing Claude Code session), it must NOT be propagated to the
+    // spawned claude subprocess. Modern claude versions read CLAUDECODE
+    // and refuse to start, exiting 1, which the spawner surfaces as the
+    // cryptic "Session exited before init" error.
+    it('strips CLAUDECODE from the spawned env even when present in process.env', async () => {
+      const { ClaudeHeadlessProvider } = await import('./headless.js');
+      const provider = new ClaudeHeadlessProvider();
+
+      const previous = process.env.CLAUDECODE;
+      process.env.CLAUDECODE = '1';
+      try {
+        const session = await provider.spawn({ workingDirectory: '/test/dir' });
+        session.close();
+
+        expect(capturedSdkOptions).toBeDefined();
+        const env = capturedSdkOptions!.env as Record<string, string> | undefined;
+        expect(env).toBeDefined();
+        expect(env!.CLAUDECODE).toBeUndefined();
+      } finally {
+        if (previous === undefined) {
+          delete process.env.CLAUDECODE;
+        } else {
+          process.env.CLAUDECODE = previous;
+        }
+      }
+    });
+
+    it('strips CLAUDECODE even when caller passes it via environmentVariables', async () => {
+      const { ClaudeHeadlessProvider } = await import('./headless.js');
+      const provider = new ClaudeHeadlessProvider();
+
+      const session = await provider.spawn({
+        workingDirectory: '/test/dir',
+        environmentVariables: { CLAUDECODE: '1', OTHER_VAR: 'keep-me' },
+      });
+      session.close();
+
+      const env = capturedSdkOptions!.env as Record<string, string> | undefined;
+      expect(env!.CLAUDECODE).toBeUndefined();
+      expect(env!.OTHER_VAR).toBe('keep-me');
+    });
+  });
 });

--- a/packages/smithy/src/providers/claude/headless.ts
+++ b/packages/smithy/src/providers/claude/headless.ts
@@ -331,9 +331,13 @@ export class ClaudeHeadlessProvider implements HeadlessProvider {
     // Build environment
     const env: Record<string, string> = {
       ...(process.env as Record<string, string>),
-      CLAUDECODE: '1',
       ...options.environmentVariables,
     };
+    // Strip CLAUDECODE so the spawned claude doesn't see itself as nested
+    // inside another Claude Code session (claude refuses to start with
+    // "Claude Code cannot be launched inside another Claude Code session"
+    // when CLAUDECODE is inherited from a parent Claude Code process).
+    delete env.CLAUDECODE;
     if (options.stoneforgeRoot) {
       env.STONEFORGE_ROOT = options.stoneforgeRoot;
     }

--- a/packages/smithy/src/providers/claude/headless.ts
+++ b/packages/smithy/src/providers/claude/headless.ts
@@ -9,6 +9,7 @@
 
 import { spawn as cpSpawn } from 'node:child_process';
 import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
+import { buildClaudeSpawnEnv } from './env.js';
 import type { Query as SDKQuery, SDKMessage, SDKUserMessage, Options as SDKOptions, SpawnOptions, SpawnedProcess } from '@anthropic-ai/claude-agent-sdk';
 import type {
   HeadlessProvider,
@@ -328,19 +329,12 @@ export class ClaudeHeadlessProvider implements HeadlessProvider {
   async spawn(options: HeadlessSpawnOptions): Promise<HeadlessSession> {
     const initialPrompt = options.initialPrompt ?? 'You are an AI agent. Await further instructions.';
 
-    // Build environment
-    const env: Record<string, string> = {
-      ...(process.env as Record<string, string>),
-      ...options.environmentVariables,
-    };
-    // Strip CLAUDECODE so the spawned claude doesn't see itself as nested
-    // inside another Claude Code session (claude refuses to start with
-    // "Claude Code cannot be launched inside another Claude Code session"
-    // when CLAUDECODE is inherited from a parent Claude Code process).
-    delete env.CLAUDECODE;
-    if (options.stoneforgeRoot) {
-      env.STONEFORGE_ROOT = options.stoneforgeRoot;
-    }
+    // Build environment via shared helper that strips CLAUDECODE
+    // (see env.ts for why this matters).
+    const env = buildClaudeSpawnEnv(process.env, {
+      overrides: options.environmentVariables,
+      stoneforgeRoot: options.stoneforgeRoot,
+    });
 
     // Create input queue for streaming input mode
     const inputQueue = new SDKInputQueue();

--- a/packages/smithy/src/providers/claude/interactive.ts
+++ b/packages/smithy/src/providers/claude/interactive.ts
@@ -120,9 +120,13 @@ export class ClaudeInteractiveProvider implements InteractiveProvider {
     // Build environment
     const env: Record<string, string> = {
       ...(process.env as Record<string, string>),
-      CLAUDECODE: '1',
       ...options.environmentVariables,
     };
+    // Strip CLAUDECODE so the spawned claude doesn't see itself as nested
+    // inside another Claude Code session (claude refuses to start with
+    // "Claude Code cannot be launched inside another Claude Code session"
+    // when CLAUDECODE is inherited from a parent Claude Code process).
+    delete env.CLAUDECODE;
     if (options.stoneforgeRoot) {
       env.STONEFORGE_ROOT = options.stoneforgeRoot;
     }

--- a/packages/smithy/src/providers/claude/interactive.ts
+++ b/packages/smithy/src/providers/claude/interactive.ts
@@ -13,6 +13,7 @@ import { dirname, join } from 'node:path';
 import { createRequire } from 'node:module';
 import * as pty from 'node-pty';
 import type { IPty } from 'node-pty';
+import { buildClaudeSpawnEnv } from './env.js';
 import type {
   InteractiveProvider,
   InteractiveSession,
@@ -117,19 +118,12 @@ export class ClaudeInteractiveProvider implements InteractiveProvider {
     const sessionId = options.resumeSessionId ?? randomUUID();
     const args = this.buildArgs(options, sessionId);
 
-    // Build environment
-    const env: Record<string, string> = {
-      ...(process.env as Record<string, string>),
-      ...options.environmentVariables,
-    };
-    // Strip CLAUDECODE so the spawned claude doesn't see itself as nested
-    // inside another Claude Code session (claude refuses to start with
-    // "Claude Code cannot be launched inside another Claude Code session"
-    // when CLAUDECODE is inherited from a parent Claude Code process).
-    delete env.CLAUDECODE;
-    if (options.stoneforgeRoot) {
-      env.STONEFORGE_ROOT = options.stoneforgeRoot;
-    }
+    // Build environment via shared helper that strips CLAUDECODE
+    // (see env.ts for why this matters).
+    const env = buildClaudeSpawnEnv(process.env, {
+      overrides: options.environmentVariables,
+      stoneforgeRoot: options.stoneforgeRoot,
+    });
 
     const cols = options.cols ?? 120;
     const rows = options.rows ?? 30;


### PR DESCRIPTION
## Summary

Closes #103.

`packages/smithy/src/providers/claude/headless.ts` and `interactive.ts` set `CLAUDECODE: '1'` in the env passed to the spawned claude subprocess. Modern claude versions read `CLAUDECODE` and refuse to start with `Claude Code cannot be launched inside another Claude Code session`. The Anthropic SDK surfaces this as `Claude Code process exited with code 1`, which the spawner swallows as the cryptic `Session exited before init`.

This blocks every spawn for users running stoneforge from inside a Claude Code session: anyone invoking `sf` from Claude Code's bash tool, or directors orchestrating workers from a Claude Code session.

The fix strips `CLAUDECODE` from the inherited env in both providers. Stoneforge IS the parent process; the spawned claude is a fresh top-level session, not nested. Issue #103 has the full diagnosis with a reproducer that captures the underlying SDK error.

## Implementation

- New shared helper `packages/smithy/src/providers/claude/env.ts`: `buildClaudeSpawnEnv(processEnv, options)` performs the merge, strips `CLAUDECODE` regardless of source (inherited or caller-supplied via `options.environmentVariables`), and sets `STONEFORGE_ROOT` when provided.
- Both `headless.ts` and `interactive.ts` now call the helper instead of duplicating the env-build logic.
- Tests:
  - `env.bun.test.ts`: 7 unit tests for the helper (CLAUDECODE strip from inherited, strip from overrides, override precedence, STONEFORGE_ROOT injection, input non-mutation).
  - `headless.bun.test.ts`: 2 integration tests that verify the headless provider's SDK call actually receives an env without CLAUDECODE.

## Why CLAUDECODE was set in the first place

Issue #32 (closed) added `CLAUDECODE: '1'` to fix Windows session permission/spawn issues. The intent was \"signal to claude that this is a managed session\". The current claude binary's check is the opposite: \"if `CLAUDECODE` is set, refuse to nest.\" Since stoneforge IS the parent (the spawned claude is fresh top-level), `CLAUDECODE` should not be in the child env.

**Windows verification welcome but not blocking.** I have not retested #32's Windows scenario. If a Windows contributor can confirm whether the unconditional strip is sufficient or whether the env needs to be platform-gated, that would be valuable. The Linux/macOS bug is reproducible 100% of the time and blocks Claude-Code-resident workflows entirely, so I'd rather ship and let any Windows regression re-file than block on verification.

## Test plan

- [x] `bun test packages/smithy/src/providers/claude` — 37 pass, 0 fail (was 28 before, +9 new tests)
- [x] `NODE_ENV=development npx turbo run typecheck --filter=@stoneforge/smithy` — clean
- [x] `NODE_ENV=development pnpm build` — clean
- [x] Manual: with daemon running on this branch in a project, ran `sf agent start <worker-id> --prompt \"...\"` from inside a Claude Code session. Pre-fix: `Failed to start agent: Session exited before init`. Post-fix: `Spawned agent <id>, Status: running`.
- [x] Changeset added (`@stoneforge/smithy: patch`).

## Related

- #102: spawner exit diagnostic enrichment. Had `Session exited before init` surfaced the underlying claude stderr (`Claude Code cannot be launched inside another Claude Code session`), this would have been a 5-minute fix instead of a multi-hour debugging session.
- #101: singleton-daemon enforcement. Independent issue, originally suspected as the cause here but disproved.
- #32: original Windows fix that introduced `CLAUDECODE='1'` (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)