### PR TITLE
fix(smithy): sf task commands honor merge.requireApproval config

### DIFF
--- a/.changeset/fix-sf-task-merge-honor-require-approval.md
+++ b/.changeset/fix-sf-task-merge-honor-require-approval.md
@@ -1,0 +1,18 @@
+---
+"@stoneforge/smithy": patch
+---
+
+fix(smithy): `sf task` commands now honor `merge.requireApproval` config
+
+The shared `createTaskAssignmentService` helper used by `sf task complete`,
+`sf task merge`, `sf task handoff`, and friends was hardcoded to wire a
+`LocalMergeProvider` regardless of workspace config. This meant the
+workflow preset `approve` (which sets `merge.requireApproval=true`) was
+silently downgraded to a no-op local merge instead of the GitHub PR flow
+the long-running orchestrator already uses in `server/services.ts`.
+
+The CLI now mirrors that wiring: when `merge.requireApproval` is true the
+CLI uses `GitHubMergeProvider`, otherwise it stays on the existing
+`LocalMergeProvider`. When `requireApproval` is true and the `gh` CLI is
+not on PATH, the command fails fast with an actionable error instead of
+silently degrading to the local provider.

--- a/packages/smithy/src/cli/commands/task.bun.test.ts
+++ b/packages/smithy/src/cli/commands/task.bun.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Task Commands Tests
+ *
+ * Tests for the shared helpers used by `sf task <subcommand>` — in particular
+ * the merge-provider selection logic that was previously hard-wired to the
+ * `LocalMergeProvider` regardless of `merge.requireApproval` config.
+ *
+ * Regression: <https://github.com/stoneforge-ai/stoneforge/issues/...>
+ */
+
+import { describe, it, expect, mock } from 'bun:test';
+import type { MergeRequestProvider, MergeRequestResult, CreateMergeRequestOptions } from '../../services/merge-request-provider.js';
+import type { Task } from '@stoneforge/core';
+import {
+  taskHandoffCommand,
+  taskCompleteCommand,
+  taskMergeCommand,
+  taskRejectCommand,
+  taskSyncCommand,
+  taskSetOwnerCommand,
+  selectMergeProvider,
+  assertGhCliAvailable,
+  type GhProbe,
+} from './task.js';
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+function makeStubProvider(name: 'local' | 'github'): MergeRequestProvider {
+  return {
+    name,
+    async createMergeRequest(_task: Task, _options: CreateMergeRequestOptions): Promise<MergeRequestResult> {
+      return { provider: name };
+    },
+  };
+}
+
+// ============================================================================
+// selectMergeProvider — the regression the fix addresses
+// ============================================================================
+
+describe('selectMergeProvider', () => {
+  const localStub = makeStubProvider('local');
+  const githubStub = makeStubProvider('github');
+
+  /** Spy factories so we can assert which one was invoked. */
+  function makeFactories() {
+    const local = mock(() => localStub);
+    const github = mock(() => githubStub);
+    return { local, github };
+  }
+
+  it('returns LocalMergeProvider when requireApproval is false', () => {
+    const factories = makeFactories();
+    const provider = selectMergeProvider({ merge: { requireApproval: false } }, factories);
+
+    expect(provider).toBe(localStub);
+    expect(provider.name).toBe('local');
+    expect(factories.local).toHaveBeenCalledTimes(1);
+    expect(factories.github).not.toHaveBeenCalled();
+  });
+
+  it('returns GitHubMergeProvider when requireApproval is true', () => {
+    const factories = makeFactories();
+    const provider = selectMergeProvider({ merge: { requireApproval: true } }, factories);
+
+    expect(provider).toBe(githubStub);
+    expect(provider.name).toBe('github');
+    expect(factories.github).toHaveBeenCalledTimes(1);
+    expect(factories.local).not.toHaveBeenCalled();
+  });
+
+  it('defaults to LocalMergeProvider when merge.requireApproval is undefined', () => {
+    const factories = makeFactories();
+    const provider = selectMergeProvider({ merge: {} }, factories);
+
+    expect(provider).toBe(localStub);
+    expect(factories.local).toHaveBeenCalledTimes(1);
+    expect(factories.github).not.toHaveBeenCalled();
+  });
+
+  it('defaults to LocalMergeProvider when merge config is absent entirely', () => {
+    const factories = makeFactories();
+    const provider = selectMergeProvider({}, factories);
+
+    expect(provider).toBe(localStub);
+    expect(factories.local).toHaveBeenCalledTimes(1);
+    expect(factories.github).not.toHaveBeenCalled();
+  });
+
+  it('treats merge.requireApproval=undefined as the default (false)', () => {
+    // Mirrors `loadConfig()` output where merge is present but the field
+    // hasn't been overridden — `?? false` should kick in and we stay local.
+    const factories = makeFactories();
+    const provider = selectMergeProvider(
+      { merge: { requireApproval: undefined } },
+      factories,
+    );
+
+    expect(provider.name).toBe('local');
+  });
+});
+
+// ============================================================================
+// assertGhCliAvailable — the new error path when gh is missing
+// ============================================================================
+
+describe('assertGhCliAvailable', () => {
+  it('resolves silently when gh is on PATH', async () => {
+    const probe: GhProbe = mock(async () => ({ available: true }));
+    await expect(assertGhCliAvailable(probe)).resolves.toBeUndefined();
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a user-friendly error when gh is missing', async () => {
+    const probe: GhProbe = mock(async () => ({
+      available: false,
+      reason: 'spawn gh ENOENT',
+    }));
+
+    await expect(assertGhCliAvailable(probe)).rejects.toThrow(
+      /Cannot create GitHub pull requests/,
+    );
+  });
+
+  it('error message references requireApproval and how to fix it', async () => {
+    const probe: GhProbe = async () => ({ available: false, reason: 'spawn gh ENOENT' });
+
+    let caught: Error | undefined;
+    try {
+      await assertGhCliAvailable(probe);
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught!.message).toContain('gh');
+    expect(caught!.message).toContain('cli.github.com');
+    expect(caught!.message).toContain('merge.requireApproval');
+  });
+
+  it('includes the probe failure reason in the error detail', async () => {
+    const probe: GhProbe = async () => ({ available: false, reason: 'spawn gh ENOENT' });
+
+    let caught: Error | undefined;
+    try {
+      await assertGhCliAvailable(probe);
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught!.message).toContain('spawn gh ENOENT');
+  });
+
+  it('omits the detail parens when probe returns no reason', async () => {
+    const probe: GhProbe = async () => ({ available: false });
+
+    let caught: Error | undefined;
+    try {
+      await assertGhCliAvailable(probe);
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).toBeDefined();
+    // Ensure we don't emit empty parentheses like "PATH (). Install …"
+    expect(caught!.message).not.toMatch(/PATH\s*\(\s*\)/);
+  });
+});
+
+// ============================================================================
+// Command structure — parity with sibling test files (agent.bun.test.ts etc.)
+// ============================================================================
+
+describe('taskHandoffCommand structure', () => {
+  it('has correct name and description', () => {
+    expect(taskHandoffCommand.name).toBe('handoff');
+    expect(typeof taskHandoffCommand.description).toBe('string');
+    expect(taskHandoffCommand.description.length).toBeGreaterThan(0);
+  });
+
+  it('exposes a handler function', () => {
+    expect(typeof taskHandoffCommand.handler).toBe('function');
+  });
+});
+
+describe('taskCompleteCommand structure', () => {
+  it('has correct name and description', () => {
+    expect(taskCompleteCommand.name).toBe('complete');
+    expect(typeof taskCompleteCommand.description).toBe('string');
+  });
+
+  it('exposes a handler function', () => {
+    expect(typeof taskCompleteCommand.handler).toBe('function');
+  });
+
+  it('declares the --no-mr option', () => {
+    const noMr = taskCompleteCommand.options!.find((o) => o.name === 'no-mr');
+    expect(noMr).toBeDefined();
+  });
+});
+
+describe('taskMergeCommand structure', () => {
+  it('has correct name and description', () => {
+    expect(taskMergeCommand.name).toBe('merge');
+    expect(typeof taskMergeCommand.description).toBe('string');
+  });
+
+  it('exposes a handler function', () => {
+    expect(typeof taskMergeCommand.handler).toBe('function');
+  });
+});
+
+describe('taskRejectCommand structure', () => {
+  it('has correct name and description', () => {
+    expect(taskRejectCommand.name).toBe('reject');
+    expect(typeof taskRejectCommand.description).toBe('string');
+  });
+
+  it('declares the --reason option', () => {
+    const reason = taskRejectCommand.options!.find((o) => o.name === 'reason');
+    expect(reason).toBeDefined();
+    expect(reason!.hasValue).toBe(true);
+  });
+});
+
+describe('taskSyncCommand structure', () => {
+  it('has correct name and description', () => {
+    expect(taskSyncCommand.name).toBe('sync');
+    expect(typeof taskSyncCommand.description).toBe('string');
+  });
+});
+
+describe('taskSetOwnerCommand structure', () => {
+  it('has correct name and description', () => {
+    expect(taskSetOwnerCommand.name).toBe('set-owner');
+    expect(typeof taskSetOwnerCommand.description).toBe('string');
+  });
+});

--- a/packages/smithy/src/cli/commands/task.ts
+++ b/packages/smithy/src/cli/commands/task.ts
@@ -13,10 +13,124 @@ import type { Command, GlobalOptions, CommandResult, CommandOption } from '@ston
 import { success, failure, ExitCode, getOutputMode } from '@stoneforge/quarry/cli';
 import type { ElementId, Task } from '@stoneforge/core';
 import { TaskStatus, createTimestamp } from '@stoneforge/core';
+import type { MergeRequestProvider } from '../../services/merge-request-provider.js';
 
 // ============================================================================
 // Shared Helpers
 // ============================================================================
+
+/**
+ * Configuration shape consumed by {@link selectMergeProvider}. Intentionally
+ * narrow — we only care about `merge.requireApproval` here, so tests don't
+ * need to construct a full `Configuration` object.
+ */
+export interface MergeProviderConfig {
+  merge?: { requireApproval?: boolean } | undefined;
+}
+
+/**
+ * Factories used by {@link selectMergeProvider}. Defaulted to the real
+ * implementations; tests pass stubs that return inert provider objects.
+ *
+ * @internal
+ */
+export interface MergeProviderFactories {
+  local: () => MergeRequestProvider;
+  github: () => MergeRequestProvider;
+}
+
+/**
+ * Selects which {@link MergeRequestProvider} the CLI should wire into the
+ * task assignment service.
+ *
+ * Mirrors the canonical pattern in `server/services.ts` so the CLI honours
+ * the same `merge.requireApproval` config the long-running orchestrator
+ * uses. Default behaviour (no config or `requireApproval=false`) is the
+ * original `LocalMergeProvider`.
+ *
+ * Exported so unit tests can exercise the conditional in isolation without
+ * touching the dynamic-import / DB-bootstrap code path of
+ * {@link createTaskAssignmentService}.
+ *
+ * @internal
+ */
+export function selectMergeProvider(
+  config: MergeProviderConfig,
+  factories: MergeProviderFactories,
+): MergeRequestProvider {
+  const requireApproval = config.merge?.requireApproval ?? false;
+  return requireApproval ? factories.github() : factories.local();
+}
+
+/**
+ * Result of probing for the `gh` CLI on PATH.
+ *
+ * @internal
+ */
+export interface GhProbeResult {
+  available: boolean;
+  /** Human-readable detail surfaced when `available` is `false`. */
+  reason?: string;
+}
+
+/**
+ * Probe-function shape used by {@link assertGhCliAvailable}. Pulled out so
+ * tests can inject a deterministic stub instead of touching `child_process`.
+ *
+ * @internal
+ */
+export type GhProbe = () => Promise<GhProbeResult>;
+
+/**
+ * Default `gh` probe — runs `gh --version` and treats a clean exit as
+ * "available". Any spawn error (most commonly `ENOENT`) is treated as
+ * unavailable. Never throws.
+ */
+async function defaultGhProbe(): Promise<GhProbeResult> {
+  const { spawn } = await import('node:child_process');
+  return new Promise<GhProbeResult>((resolve) => {
+    let settled = false;
+    const settle = (result: GhProbeResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    try {
+      const proc = spawn('gh', ['--version'], { stdio: 'ignore' });
+      proc.on('error', (err: Error) => {
+        settle({ available: false, reason: err.message });
+      });
+      proc.on('close', (code: number | null) => {
+        if (code === 0) settle({ available: true });
+        else settle({ available: false, reason: `gh --version exited with code ${code}` });
+      });
+    } catch (err) {
+      settle({ available: false, reason: err instanceof Error ? err.message : String(err) });
+    }
+  });
+}
+
+/**
+ * Throws a user-friendly error if the `gh` CLI is not available on PATH.
+ *
+ * Used when `merge.requireApproval=true` so we fail loudly with actionable
+ * guidance instead of silently falling back to the no-op local provider —
+ * that silent fallback is the original bug we're fixing.
+ *
+ * @internal
+ */
+export async function assertGhCliAvailable(probe: GhProbe = defaultGhProbe): Promise<void> {
+  const result = await probe();
+  if (result.available) return;
+
+  const detail = result.reason ? ` (${result.reason})` : '';
+  throw new Error(
+    `Cannot create GitHub pull requests: the \`gh\` CLI is not available on PATH${detail}. ` +
+    'Install it from https://cli.github.com/ and run `gh auth login`, or set ' +
+    '`merge.requireApproval` to `false` in your workspace config to use the local merge provider.'
+  );
+}
 
 /**
  * Creates task assignment service
@@ -26,9 +140,9 @@ async function createTaskAssignmentService(options: GlobalOptions): Promise<{
   error?: string;
 }> {
   try {
-    const { createStorage, initializeSchema, findStoneforgeDir } = await import('@stoneforge/quarry');
+    const { createStorage, initializeSchema, findStoneforgeDir, loadConfig } = await import('@stoneforge/quarry');
     const { createTaskAssignmentService: createService } = await import('../../services/task-assignment-service.js');
-    const { createLocalMergeProvider } = await import('../../services/merge-request-provider.js');
+    const { createLocalMergeProvider, createGitHubMergeProvider } = await import('../../services/merge-request-provider.js');
     const { QuarryAPIImpl } = await import('@stoneforge/quarry');
 
     const stoneforgeDir = findStoneforgeDir(process.cwd());
@@ -43,7 +157,22 @@ async function createTaskAssignmentService(options: GlobalOptions): Promise<{
     const backend = createStorage({ path: dbPath, create: true });
     initializeSchema(backend);
     const api = new QuarryAPIImpl(backend);
-    const mergeProvider = createLocalMergeProvider();
+
+    // Mirror the wiring used in server/services.ts so CLI behaviour matches the
+    // long-running orchestrator: when the workspace requires approval, route
+    // through the GitHub provider; otherwise fall back to the no-op local one.
+    const config = loadConfig();
+    const requireApproval = config.merge?.requireApproval ?? false;
+    if (requireApproval) {
+      // Fail early with actionable guidance instead of silently degrading to
+      // LocalMergeProvider when `gh` is missing.
+      await assertGhCliAvailable();
+    }
+    const mergeProvider = selectMergeProvider(config, {
+      local: createLocalMergeProvider,
+      github: createGitHubMergeProvider,
+    });
+
     const { dirname } = await import('node:path');
     const workspaceRoot = dirname(stoneforgeDir);
     const service = createService(api, mergeProvider, workspaceRoot);


### PR DESCRIPTION
## Summary

`sf task` subcommands (`complete`, `merge`, `handoff`, `reject`, `sync`) silently bypass `merge.requireApproval` because the shared helper that wires their merge provider is hardcoded to `LocalMergeProvider`. Workspaces using the `approve` workflow preset never see GitHub PRs created from the CLI even though the long-running orchestrator (`server/services.ts`) does the right thing — the CLI just no-ops.

## Problem

In `packages/smithy/src/cli/commands/task.ts`, `createTaskAssignmentService(options)` (the helper every `sf task ...` subcommand routes through) builds the merge provider with:

```ts
const mergeProvider = createLocalMergeProvider();
```

That wiring ignores `config.merge.requireApproval` entirely. Server-side, `packages/smithy/src/server/services.ts` already does the right thing:

```ts
const requireApproval = config.merge?.requireApproval ?? false;
mergeRequestProvider: requireApproval ? createGitHubMergeProvider() : undefined,
```

So setting the workspace to the `approve` preset turns on PR creation only when the orchestrator runs work — invoking `sf task complete <id>` from the CLI silently falls back to a no-op local merge instead of opening a GitHub PR. From the user's POV, the workflow preset is broken.

## Root cause

`packages/smithy/src/cli/commands/task.ts:46` (pre-fix) — `const mergeProvider = createLocalMergeProvider();` runs unconditionally inside `createTaskAssignmentService`, with no read of `loadConfig()` or `config.merge.requireApproval`.

## Fix

`createTaskAssignmentService` now mirrors the canonical pattern from `server/services.ts`:

1. `loadConfig()` is destructured from `@stoneforge/quarry` (the same module the helper already imports dynamically).
2. The merge provider selection is delegated to a small new helper `selectMergeProvider(config, factories)` which returns `GitHubMergeProvider` when `config.merge?.requireApproval === true` and `LocalMergeProvider` otherwise. The helper is exported (`@internal`) so unit tests can pass stub factories.
3. When `requireApproval` is true, a new `assertGhCliAvailable()` runs `gh --version` and throws a user-friendly error if `gh` is missing on PATH — instead of silently degrading to `LocalMergeProvider` (the original bug). The error tells the user how to install `gh` or how to flip `requireApproval` back to false.

Default behaviour is unchanged: when `requireApproval` is unset, false, or `merge` is absent entirely, `LocalMergeProvider` is used exactly as before.

## Changes

- `packages/smithy/src/cli/commands/task.ts` — load config and select provider conditionally; export `selectMergeProvider`, `assertGhCliAvailable`, and the supporting types for tests.
- `packages/smithy/src/cli/commands/task.bun.test.ts` — new test file (no `task.bun.test.ts` existed previously) covering provider selection, the gh-missing error path, and command-structure parity with sibling test files.
- `.changeset/fix-sf-task-merge-honor-require-approval.md` — patch bump for `@stoneforge/smithy`.

## Test coverage

New cases in `task.bun.test.ts`:

**`selectMergeProvider`** (the regression):
- Default behaviour preserved — `requireApproval=false` → LocalMergeProvider, github factory not invoked.
- GitHub flow engaged — `requireApproval=true` → GitHubMergeProvider, local factory not invoked.
- `merge.requireApproval` is `undefined` → falls back to LocalMergeProvider (`?? false`).
- `merge` config absent entirely → falls back to LocalMergeProvider.
- `merge.requireApproval` is explicitly `undefined` → falls back to LocalMergeProvider.

**`assertGhCliAvailable`** (the new error path):
- Resolves silently when probe reports `available: true`.
- Throws with `Cannot create GitHub pull requests` when probe reports `available: false`.
- Error message references `cli.github.com` and `merge.requireApproval` so users know how to fix it.
- Probe failure reason is included in the detail.
- No empty `()` when the probe gives no reason.

**Command-structure parity** with `task-merge-status.bun.test.ts` / `agent.bun.test.ts`:
- Smoke checks on `name`/`description`/`handler` for `taskHandoffCommand`, `taskCompleteCommand`, `taskMergeCommand`, `taskRejectCommand`, `taskSyncCommand`, `taskSetOwnerCommand` plus a few key options (`--no-mr`, `--reason`).

All 21 new tests pass; the package's full Bun suite (`bun test src`) is green at 1589 pass / 0 fail / 19 skip.

## Test plan

- [x] `pnpm install` at the monorepo root.
- [x] `cd packages/smithy && pnpm run typecheck` — clean.
- [x] `cd packages/smithy && pnpm run build` — clean (compiled `dist/cli/commands/task.js` reflects the fix).
- [x] `cd packages/smithy && bun test src/cli/commands/task.bun.test.ts` — 21 pass, 0 fail.
- [x] `cd packages/smithy && pnpm run test` — 1589 pass, 0 fail, 19 skip across 53 files.
- [x] Manual smoke on a temp workspace with three configs:
  1. `merge.requireApproval=true`, `gh` stripped from PATH → command exits with the new clear error: `Cannot create GitHub pull requests: the \`gh\` CLI is not available on PATH (Executable not found in $PATH: "gh"). Install it from https://cli.github.com/ and run \`gh auth login\`, or set \`merge.requireApproval\` to \`false\` in your workspace config to use the local merge provider.`
  2. `merge.requireApproval=false` → command proceeds past provider initialization (errors later on the unrelated "Task not found" lookup, exactly as on master).
  3. `merge.requireApproval=true`, `gh` available → command proceeds past provider initialization (same "Task not found" downstream error, confirming gh check passes).

## Checklist

- [x] Tests pass
- [x] Typecheck passes
- [x] Changeset added (if applicable)