### PR TITLE
fix(quarry): external-sync now propagates closed task state to remote

### DIFF
--- a/.changeset/fix-sync-engine-propagate-closed-task-state.md
+++ b/.changeset/fix-sync-engine-propagate-closed-task-state.md
@@ -1,0 +1,23 @@
+---
+"@stoneforge/quarry": patch
+---
+
+fix(quarry): external-sync now propagates closed task state to remote
+
+`pushSingleElement` in the external-sync engine was unconditionally
+skipping every element whose status was `closed`, with a comment claiming
+"they're done and shouldn't sync". That was wrong — the *close transition
+itself* is what needs to be pushed. As a result, GitHub issues linked via
+auto-link stayed OPEN forever after the linked Stoneforge task was closed,
+and their `sf:status:open` label was never updated to `sf:status:closed`.
+
+The fix removes `closed` from the early-skip guard in
+`pushSingleElement`. The downstream hash and event checks in
+`pushElement`/`pushDocument` already dedupe pushes (`lastPushedHash` and
+the `updated/closed/reopened` events query), so the change is safe and
+self-throttling — a closed task is pushed exactly once per close
+transition, not on every subsequent sync.
+
+Tombstones (deleted tasks) and archived documents remain in the early-
+skip guard: those are terminal states that shouldn't generate any further
+sync traffic.

--- a/packages/quarry/src/external-sync/sync-engine.bun.test.ts
+++ b/packages/quarry/src/external-sync/sync-engine.bun.test.ts
@@ -1151,7 +1151,12 @@ describe('Error classification', () => {
 describe('SyncEngine closed/tombstone task filtering', () => {
   // --- Push path ---
 
-  test('push skips closed tasks', async () => {
+  test('push propagates closed tasks so the close-event reaches the remote', async () => {
+    // Regression: previously, closed tasks were unconditionally skipped on
+    // push, which left the linked GitHub issue OPEN forever and its
+    // sf:status:* label out of date. The close transition itself is the
+    // change that needs to be pushed; downstream hash + event checks
+    // dedupe subsequent pushes.
     const syncState = createTestSyncState({
       lastPushedHash: 'old-hash-that-differs',
       lastPushedAt: '2024-01-01T00:00:00.000Z' as Timestamp,
@@ -1161,12 +1166,82 @@ describe('SyncEngine closed/tombstone task filtering', () => {
       status: 'closed',
     } as unknown as Element;
 
+    let capturedUpdates: Partial<ExternalTaskInput> | undefined;
+    const engine = buildEngine({
+      elements: [element],
+      events: [
+        { elementId: element.id, eventType: 'closed', createdAt: '2024-01-05T00:00:00.000Z' as Timestamp },
+      ],
+      onUpdateIssue: (_project, _externalId, updates) => {
+        capturedUpdates = updates;
+      },
+    });
+
+    const result = await engine.push({ all: true });
+    expect(result.pushed).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(capturedUpdates).toBeDefined();
+    // The remote state must reflect the closure so the linked GitHub issue
+    // closes and its sf:status:* labels update.
+    expect(capturedUpdates!.state).toBe('closed');
+  });
+
+  test('push closed task: idempotent — skipped when lastPushedHash matches current hash', async () => {
+    // After removing the early `closed` skip, downstream hash dedupe must
+    // still prevent re-pushing a task whose content (including closed state)
+    // has not changed since the last push.
+    const baseElement = {
+      ...createTestElement({ _syncState: createTestSyncState() }),
+      status: 'closed',
+    } as unknown as Element;
+
+    const { computeContentHashSync } = await import('../sync/hash.js');
+    const matchingHash = computeContentHashSync(baseElement).hash;
+
+    const element = {
+      ...createTestElement({
+        _syncState: createTestSyncState({
+          lastPushedHash: matchingHash,
+          lastPushedAt: '2024-01-01T00:00:00.000Z' as Timestamp,
+        }),
+      }),
+      status: 'closed',
+    } as unknown as Element;
+
     let updateCalled = false;
     const engine = buildEngine({
       elements: [element],
       events: [
-        { elementId: element.id, eventType: 'updated', createdAt: '2024-01-05T00:00:00.000Z' as Timestamp },
+        { elementId: element.id, eventType: 'closed', createdAt: '2024-01-05T00:00:00.000Z' as Timestamp },
       ],
+      onUpdateIssue: () => {
+        updateCalled = true;
+      },
+    });
+
+    const result = await engine.push({ all: true });
+    expect(updateCalled).toBe(false);
+    expect(result.pushed).toBe(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  test('push closed task: skipped when no updated/closed/reopened events since lastPushedAt', async () => {
+    // Downstream event-based dedupe must still kick in for closed tasks:
+    // if no relevant events have occurred since the last push, there is
+    // nothing new to propagate.
+    const syncState = createTestSyncState({
+      lastPushedHash: 'different-old-hash',
+      lastPushedAt: '2024-01-02T00:00:00.000Z' as Timestamp,
+    });
+    const element = {
+      ...createTestElement({ _syncState: syncState }),
+      status: 'closed',
+    } as unknown as Element;
+
+    let updateCalled = false;
+    const engine = buildEngine({
+      elements: [element],
+      events: [], // no updated/closed/reopened events since lastPushedAt
       onUpdateIssue: () => {
         updateCalled = true;
       },

--- a/packages/quarry/src/external-sync/sync-engine.ts
+++ b/packages/quarry/src/external-sync/sync-engine.ts
@@ -392,11 +392,16 @@ export class SyncEngine {
       return 'skipped';
     }
 
-    // Skip closed/tombstone tasks and archived documents — they're done
-    // and shouldn't sync. If an element is later reopened/reactivated,
-    // it will be picked up again naturally since the filter no longer applies.
+    // Closed tasks must still push — the close transition itself needs to
+    // reach the remote so the linked issue closes and its sf:status:* label
+    // updates. Downstream hash + event checks in pushElement/pushDocument
+    // dedupe subsequent pushes, so this is safe and self-throttling.
+    //
+    // Tombstones (deleted tasks) and archived documents stay skipped:
+    // they're terminal states that shouldn't generate any further sync
+    // traffic.
     const elementStatus = (element as unknown as { status: string }).status;
-    if (elementStatus === 'closed' || elementStatus === 'tombstone' || elementStatus === 'archived') {
+    if (elementStatus === 'tombstone' || elementStatus === 'archived') {
       return 'skipped';
     }
 


### PR DESCRIPTION
## Problem

`pushSingleElement` in `packages/quarry/src/external-sync/sync-engine.ts` skipped every element whose status was `closed`, with a comment claiming "they're done and shouldn't sync". That's wrong — the *close transition itself* is what needs to be pushed. As a result, GitHub issues linked via auto-link stayed OPEN forever after the corresponding Stoneforge task was closed, and their `sf:status:open` label was never replaced with `sf:status:closed`.

## Root cause

`packages/quarry/src/external-sync/sync-engine.ts` (pre-fix), inside `pushSingleElement`:

```ts
// Skip closed/tombstone tasks and archived documents — they're done
// and shouldn't sync. If an element is later reopened/reactivated,
// it will be picked up again naturally since the filter no longer applies.
const elementStatus = (element as unknown as { status: string }).status;
if (elementStatus === 'closed' || elementStatus === 'tombstone' || elementStatus === 'archived') {
  return 'skipped';
}
```

`'closed'` short-circuited the push *before* `pushElement` could compare hashes or query events, so the close transition never reached the adapter.

## Fix

Remove `closed` from the early-skip guard. The downstream `lastPushedHash` comparison and `listEvents({ eventType: ['updated', 'closed', 'reopened'], after: lastPushedAt })` query in `pushElement`/`pushDocument` already dedupe subsequent pushes, so the change is safe and self-throttling — a closed task is pushed exactly once per close transition, not on every subsequent sync. Tombstones (deleted tasks) and archived documents stay in the skip guard as terminal states that shouldn't generate any further sync traffic. The surrounding comment is updated to explain *why* closed tasks must still push.

## Test coverage

`packages/quarry/src/external-sync/sync-engine.bun.test.ts`:

- **Regression — closed task is pushed**: `push propagates closed tasks so the close-event reaches the remote` — replaces the previous test that asserted the buggy behavior. Verifies the adapter's `updateIssue` is called and that the captured payload's `state` is `'closed'`, so the linked GitHub issue closes and its `sf:status:*` label updates.
- **Tombstone still skipped**: `push skips tombstone tasks` — unchanged. Verifies tombstone tasks are still excluded from push.
- **Archived doc still skipped**: `skips archived documents on push` — unchanged (in the document push describe block). Verifies archived documents are still excluded.
- **Idempotency / hash dedupe**: `push closed task: idempotent — skipped when lastPushedHash matches current hash` — new. Computes the actual content hash of a closed task, sets `lastPushedHash` to that value, asserts the push is skipped via the downstream hash check (proving dedupe still works after the early-skip removal).
- **Event-based skip**: `push closed task: skipped when no updated/closed/reopened events since lastPushedAt` — new. Verifies that a closed task with no relevant events since the last push is skipped via the downstream `listEvents` guard.
- **Reopen path**: `push resumes syncing when task is reopened (status no longer closed/tombstone)` — unchanged. Verifies that reopening a previously-closed task pushes again.

Full quarry suite: `bun test src` → **4262 pass, 1 skip, 0 fail** (95 files). `pnpm run typecheck` and `pnpm run build` clean.

## Manual verification

End-to-end on a temporary workspace:

1. `sf init` a fresh workspace; auto-link a Stoneforge task to a GitHub issue (`sf external-sync link <task-id> <issue-url>`).
2. Confirm the issue is OPEN and labeled `sf:status:open`.
3. `sf task complete <task-id>` (closes the task).
4. `sf external-sync push <task-id>`.
5. Observe: the GitHub issue is now CLOSED, the `sf:status:open` label has been replaced with `sf:status:closed`, and the local task's `_externalSync.lastPushedAt`/`lastPushedHash` are updated.
6. Re-run `sf external-sync push <task-id>` immediately. Observe: the task is reported as `skipped` (downstream hash dedupe), confirming the fix is self-throttling.