### PR TITLE
[codex] fix(smithy): update Codex interactive CLI flags

### DIFF
--- a/.changeset/fix-codex-interactive-cli-flags.md
+++ b/.changeset/fix-codex-interactive-cli-flags.md
@@ -1,0 +1,5 @@
+---
+"@stoneforge/smithy": patch
+---
+
+Fix Codex interactive sessions to use supported CLI flags instead of the removed `--full-auto` option.

--- a/packages/smithy/src/providers/codex/interactive.ts
+++ b/packages/smithy/src/providers/codex/interactive.ts
@@ -158,11 +158,12 @@ export class CodexInteractiveProvider implements InteractiveProvider {
 
   private buildArgs(options: InteractiveSpawnOptions): string[] {
     const args: string[] = [];
+    const autoRunFlags = ['--sandbox', 'workspace-write', '--ask-for-approval', 'never'];
 
     if (options.resumeSessionId) {
-      args.push('resume', shellQuote(options.resumeSessionId), '--full-auto');
+      args.push(...autoRunFlags, 'resume', shellQuote(options.resumeSessionId));
     } else {
-      args.push('--full-auto', '--cd', shellQuote(options.workingDirectory));
+      args.push(...autoRunFlags, '--cd', shellQuote(options.workingDirectory));
     }
 
     // Add model flag if provided

--- a/packages/smithy/src/providers/codex/provider.bun.test.ts
+++ b/packages/smithy/src/providers/codex/provider.bun.test.ts
@@ -214,11 +214,12 @@ describe('CodexInteractiveProvider model flag', () => {
   }): string[] {
     const shellQuote = posixShellQuote;
     const args: string[] = [];
+    const autoRunFlags = ['--sandbox', 'workspace-write', '--ask-for-approval', 'never'];
 
     if (options.resumeSessionId) {
-      args.push('resume', shellQuote(options.resumeSessionId), '--full-auto');
+      args.push(...autoRunFlags, 'resume', shellQuote(options.resumeSessionId));
     } else {
-      args.push('--full-auto', '--cd', shellQuote(options.workingDirectory));
+      args.push(...autoRunFlags, '--cd', shellQuote(options.workingDirectory));
     }
 
     // Add model flag if provided
@@ -237,7 +238,16 @@ describe('CodexInteractiveProvider model flag', () => {
 
     expect(args).toContain('--model');
     expect(args).toContain("'gpt-4o'");
-    expect(args).toEqual(['--full-auto', '--cd', "'/workspace'", '--model', "'gpt-4o'"]);
+    expect(args).toEqual([
+      '--sandbox',
+      'workspace-write',
+      '--ask-for-approval',
+      'never',
+      '--cd',
+      "'/workspace'",
+      '--model',
+      "'gpt-4o'",
+    ]);
   });
 
   it('should not include --model flag when model is undefined', () => {
@@ -246,7 +256,15 @@ describe('CodexInteractiveProvider model flag', () => {
     });
 
     expect(args).not.toContain('--model');
-    expect(args).toEqual(['--full-auto', '--cd', "'/workspace'"]);
+    expect(args).not.toContain('--full-auto');
+    expect(args).toEqual([
+      '--sandbox',
+      'workspace-write',
+      '--ask-for-approval',
+      'never',
+      '--cd',
+      "'/workspace'",
+    ]);
   });
 
   it('should include --model flag when resuming with model', () => {
@@ -256,9 +274,17 @@ describe('CodexInteractiveProvider model flag', () => {
       model: 'o3-mini',
     });
 
-    expect(args).toContain('resume');
-    expect(args).toContain('--model');
-    expect(args).toContain("'o3-mini'");
+    expect(args).not.toContain('--full-auto');
+    expect(args).toEqual([
+      '--sandbox',
+      'workspace-write',
+      '--ask-for-approval',
+      'never',
+      'resume',
+      "'thr_abc123'",
+      '--model',
+      "'o3-mini'",
+    ]);
   });
 
   it('should properly quote model names with special characters', () => {


### PR DESCRIPTION
## Summary

- Replace Codex interactive `--full-auto` launches with supported `--sandbox workspace-write --ask-for-approval never` flags.
- Apply the replacement to both fresh interactive sessions and resumed sessions.
- Update Smithy provider tests and add a patch changeset for `@stoneforge/smithy`.

## Root Cause

Recent Codex CLI versions reject `--full-auto`, so Director and persistent-worker interactive PTYs exit before the Codex TUI starts.

## Evidence

Local reproduction against the currently installed Codex CLI:

```console
$ codex --version
codex-cli 0.128.0
```

```console
$ codex --full-auto --help
error: unexpected argument '--full-auto' found

  tip: to pass '--full-auto' as a value, use '-- --full-auto'

Usage: codex [OPTIONS] [PROMPT]
       codex [OPTIONS] <COMMAND> [ARGS]

For more information, try '--help'.
```

`codex --help` lists the replacement flags used here:

```console
-s, --sandbox <SANDBOX_MODE>
-a, --ask-for-approval <APPROVAL_POLICY>
-C, --cd <DIR>
```

## Validation

- `bun test src/providers/codex/provider.bun.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run test`