### PR TITLE
fix: update codex interactive cli flags

### DIFF
--- a/.changeset/fix-codex-cli-flags.md
+++ b/.changeset/fix-codex-cli-flags.md
@@ -1,0 +1,5 @@
+---
+"@stoneforge/smithy": patch
+---
+
+Fix Codex interactive provider startup with current Codex CLI releases.

--- a/packages/smithy/src/providers/codex/interactive.ts
+++ b/packages/smithy/src/providers/codex/interactive.ts
@@ -8,6 +8,7 @@
  */
 
 import * as pty from 'node-pty';
+import { execSync } from 'node:child_process';
 import type { IPty } from 'node-pty';
 import type {
   InteractiveProvider,
@@ -89,6 +90,7 @@ class CodexInteractiveSession implements InteractiveSession {
 export class CodexInteractiveProvider implements InteractiveProvider {
   readonly name = 'codex-interactive';
   private readonly executablePath: string;
+  private supportsFullAutoFlag: boolean | undefined;
 
   constructor(executablePath = 'codex') {
     this.executablePath = executablePath;
@@ -158,11 +160,22 @@ export class CodexInteractiveProvider implements InteractiveProvider {
 
   private buildArgs(options: InteractiveSpawnOptions): string[] {
     const args: string[] = [];
+    const automationArgs = this.buildAutomationArgs();
 
     if (options.resumeSessionId) {
-      args.push('resume', shellQuote(options.resumeSessionId), '--full-auto');
+      args.push(
+        'resume',
+        ...automationArgs,
+        '--cd',
+        shellQuote(options.workingDirectory),
+        shellQuote(options.resumeSessionId),
+      );
     } else {
-      args.push('--full-auto', '--cd', shellQuote(options.workingDirectory));
+      args.push(
+        ...automationArgs,
+        '--cd',
+        shellQuote(options.workingDirectory),
+      );
     }
 
     // Add model flag if provided
@@ -171,5 +184,31 @@ export class CodexInteractiveProvider implements InteractiveProvider {
     }
 
     return args;
+  }
+
+  private buildAutomationArgs(): string[] {
+    if (this.supportsFullAuto()) {
+      return ['--full-auto'];
+    }
+
+    return ['--ask-for-approval', 'never', '--sandbox', 'workspace-write'];
+  }
+
+  private supportsFullAuto(): boolean {
+    if (this.supportsFullAutoFlag !== undefined) {
+      return this.supportsFullAutoFlag;
+    }
+
+    try {
+      const help = execSync(`${shellQuote(this.executablePath)} --help`, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      this.supportsFullAutoFlag = help.includes('--full-auto');
+    } catch {
+      this.supportsFullAutoFlag = false;
+    }
+
+    return this.supportsFullAutoFlag;
   }
 }

--- a/packages/smithy/src/providers/codex/provider.bun.test.ts
+++ b/packages/smithy/src/providers/codex/provider.bun.test.ts
@@ -211,14 +211,28 @@ describe('CodexInteractiveProvider model flag', () => {
     resumeSessionId?: string;
     workingDirectory: string;
     model?: string;
+    supportsFullAuto?: boolean;
   }): string[] {
     const shellQuote = posixShellQuote;
     const args: string[] = [];
+    const automationArgs = (options.supportsFullAuto ?? true)
+      ? ['--full-auto']
+      : ['--ask-for-approval', 'never', '--sandbox', 'workspace-write'];
 
     if (options.resumeSessionId) {
-      args.push('resume', shellQuote(options.resumeSessionId), '--full-auto');
+      args.push(
+        'resume',
+        ...automationArgs,
+        '--cd',
+        shellQuote(options.workingDirectory),
+        shellQuote(options.resumeSessionId),
+      );
     } else {
-      args.push('--full-auto', '--cd', shellQuote(options.workingDirectory));
+      args.push(
+        ...automationArgs,
+        '--cd',
+        shellQuote(options.workingDirectory),
+      );
     }
 
     // Add model flag if provided
@@ -237,7 +251,13 @@ describe('CodexInteractiveProvider model flag', () => {
 
     expect(args).toContain('--model');
     expect(args).toContain("'gpt-4o'");
-    expect(args).toEqual(['--full-auto', '--cd', "'/workspace'", '--model', "'gpt-4o'"]);
+    expect(args).toEqual([
+      '--full-auto',
+      '--cd',
+      "'/workspace'",
+      '--model',
+      "'gpt-4o'",
+    ]);
   });
 
   it('should not include --model flag when model is undefined', () => {
@@ -246,7 +266,27 @@ describe('CodexInteractiveProvider model flag', () => {
     });
 
     expect(args).not.toContain('--model');
-    expect(args).toEqual(['--full-auto', '--cd', "'/workspace'"]);
+    expect(args).toEqual([
+      '--full-auto',
+      '--cd',
+      "'/workspace'",
+    ]);
+  });
+
+  it('should fall back to explicit approval and sandbox flags when --full-auto is unavailable', () => {
+    const args = buildArgs({
+      workingDirectory: '/workspace',
+      supportsFullAuto: false,
+    });
+
+    expect(args).toEqual([
+      '--ask-for-approval',
+      'never',
+      '--sandbox',
+      'workspace-write',
+      '--cd',
+      "'/workspace'",
+    ]);
   });
 
   it('should include --model flag when resuming with model', () => {
@@ -257,6 +297,8 @@ describe('CodexInteractiveProvider model flag', () => {
     });
 
     expect(args).toContain('resume');
+    expect(args).toContain('--full-auto');
+    expect(args).toContain('--cd');
     expect(args).toContain('--model');
     expect(args).toContain("'o3-mini'");
   });


### PR DESCRIPTION
## Summary

- keep Codex interactive sessions on `--full-auto` when the installed CLI still supports it
- fall back to `--ask-for-approval never --sandbox workspace-write` for newer Codex CLIs that removed `--full-auto`
- preserve the intended working directory for resumed Codex sessions by passing `--cd`
- add a patch changeset for `@stoneforge/smithy`

Fixes #114.

## Verification

```bash
bun test src/providers/codex/provider.bun.test.ts
pnpm --filter @stoneforge/smithy typecheck
pnpm --filter @stoneforge/smithy build
codex --ask-for-approval never --sandbox workspace-write --cd /Users/furquanuddin94/.codex/worktrees/8db2/stoneforge --version
codex resume --ask-for-approval never --sandbox workspace-write --cd /Users/furquanuddin94/.codex/worktrees/8db2/stoneforge --help
```
