### PR TITLE
fix(smithy): release agent pool slots on session end

### DIFF
--- a/.changeset/calm-codex-flags.md
+++ b/.changeset/calm-codex-flags.md
@@ -1,0 +1,5 @@
+---
+"@stoneforge/smithy": patch
+---
+
+Update Codex interactive sessions to use the documented workspace-write sandbox flag.

--- a/.changeset/fresh-pools-rest.md
+++ b/.changeset/fresh-pools-rest.md
@@ -1,0 +1,5 @@
+---
+"@stoneforge/smithy": patch
+---
+
+Release agent pool slots when worker or steward sessions leave active execution.

--- a/.changeset/fresh-pools-rest.md
+++ b/.changeset/fresh-pools-rest.md
@@ -2,4 +2,4 @@
 "@stoneforge/smithy": patch
 ---
 
-Release agent pool slots when worker or steward sessions leave active execution.
+Fix agent pool slot accounting so worker and steward slots are released when sessions leave active execution. Pool reservations now happen before session startup, are released if startup fails, and session restarts wait for prior session-end cleanup so stale callbacks cannot corrupt pool capacity.

--- a/.changeset/quiet-codex-resume.md
+++ b/.changeset/quiet-codex-resume.md
@@ -1,0 +1,5 @@
+---
+"@stoneforge/smithy": patch
+---
+
+Fix Codex interactive resume so only UUID session IDs from the Codex continuation footer are persisted. Stopping an interactive Codex session now requests a clean `/exit` shutdown, allowing Stoneforge to capture the resume ID and avoid offering invalid resume targets from ordinary terminal text.

--- a/apps/smithy-server/src/routes/sessions.ts
+++ b/apps/smithy-server/src/routes/sessions.ts
@@ -15,6 +15,7 @@ import { formatSessionRecord } from '../formatters.js';
 import { notifySSEClientsOfNewSession } from './events.js';
 
 const logger = createLogger('sessions');
+const CODEX_RESUME_SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 type NotifyClientsCallback = (
   agentId: EntityId,
@@ -591,6 +592,17 @@ Please begin working on this task. Use \`sf task get ${taskResult.id}\` to see f
           return c.json({ error: { code: 'NO_RESUMABLE_SESSION', message: 'No resumable session found' } }, 404);
         }
         providerSessionId = resumable.providerSessionId;
+      }
+
+      const meta = getAgentMetadata(agent);
+      if ((meta as { provider?: string } | undefined)?.provider === 'codex'
+        && !CODEX_RESUME_SESSION_ID_PATTERN.test(providerSessionId)) {
+        return c.json({
+          error: {
+            code: 'INVALID_PROVIDER_SESSION_ID',
+            message: 'Codex resume requires a valid UUID session ID',
+          },
+        }, 400);
       }
 
       const { session, events, uwpCheck } = await sessionManager.resumeSession(agentId, {

--- a/apps/smithy-web/src/api/hooks/useAgents.ts
+++ b/apps/smithy-web/src/api/hooks/useAgents.ts
@@ -25,6 +25,17 @@ import type {
 // ============================================================================
 
 const API_BASE = '/api';
+const CODEX_RESUME_SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function hasValidProviderSessionIdForAgent(agent: Agent, session: unknown): session is { providerSessionId: string } {
+  const providerSessionId = (session as { providerSessionId?: unknown } | null)?.providerSessionId;
+  if (typeof providerSessionId !== 'string' || providerSessionId.length === 0) {
+    return false;
+  }
+
+  return agent.metadata?.agent?.provider !== 'codex'
+    || CODEX_RESUME_SESSION_ID_PATTERN.test(providerSessionId);
+}
 
 async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, {
@@ -211,25 +222,23 @@ export function useDirectors(): {
     })),
   });
 
-  const directors: DirectorInfo[] = useMemo(() => {
-    return (directorAgents ?? []).map((director, i) => {
-      const query = statusQueries[i];
-      const statusData = query?.data;
-      const history = statusData?.recentHistory ?? [];
-      const lastResumableSession = history.find((h) => !!h.providerSessionId) ?? null;
+  const directors: DirectorInfo[] = (directorAgents ?? []).map((director, i) => {
+    const query = statusQueries[i];
+    const statusData = query?.data;
+    const history = statusData?.recentHistory ?? [];
+    const lastResumableSession = history.find((h) => hasValidProviderSessionIdForAgent(director, h)) ?? null;
 
-      return {
-        director,
-        hasActiveSession: statusData?.hasActiveSession ?? false,
-        activeSession: statusData?.activeSession ?? null,
-        recentHistory: history,
-        lastResumableSession,
-        hasResumableSession: lastResumableSession !== null,
-        isLoading: query?.isLoading ?? true,
-        error: (query?.error as Error) ?? null,
-      };
-    });
-  }, [directorAgents, statusQueries]);
+    return {
+      director,
+      hasActiveSession: statusData?.hasActiveSession ?? false,
+      activeSession: statusData?.activeSession ?? null,
+      recentHistory: history,
+      lastResumableSession,
+      hasResumableSession: lastResumableSession !== null,
+      isLoading: query?.isLoading ?? true,
+      error: (query?.error as Error) ?? null,
+    };
+  });
 
   const isLoading = agentsLoading || statusQueries.some(q => q.isLoading);
   const combinedError = agentsError ?? statusQueries.find(q => q.error)?.error ?? null;

--- a/packages/smithy/src/providers/codex/interactive.ts
+++ b/packages/smithy/src/providers/codex/interactive.ts
@@ -21,6 +21,31 @@ import { shellQuote } from '../shell-quote.js';
 // Helpers
 // ============================================================================
 
+type CodexInteractiveArgOptions = Pick<
+  InteractiveSpawnOptions,
+  'resumeSessionId' | 'workingDirectory' | 'model'
+>;
+
+export function buildCodexInteractiveArgs(
+  options: CodexInteractiveArgOptions,
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  const quote = (value: string) => shellQuote(value, platform);
+  const args: string[] = [];
+
+  if (options.resumeSessionId) {
+    args.push('resume', quote(options.resumeSessionId), '--sandbox', 'workspace-write');
+  } else {
+    args.push('--sandbox', 'workspace-write', '--cd', quote(options.workingDirectory));
+  }
+
+  if (options.model) {
+    args.push('--model', quote(options.model));
+  }
+
+  return args;
+}
+
 // ============================================================================
 // Codex Interactive Session
 // ============================================================================
@@ -95,7 +120,7 @@ export class CodexInteractiveProvider implements InteractiveProvider {
   }
 
   async spawn(options: InteractiveSpawnOptions): Promise<InteractiveSession> {
-    const args = this.buildArgs(options);
+    const args = buildCodexInteractiveArgs(options);
 
     const env: Record<string, string> = {
       ...(process.env as Record<string, string>),
@@ -156,20 +181,4 @@ export class CodexInteractiveProvider implements InteractiveProvider {
     }
   }
 
-  private buildArgs(options: InteractiveSpawnOptions): string[] {
-    const args: string[] = [];
-
-    if (options.resumeSessionId) {
-      args.push('resume', shellQuote(options.resumeSessionId), '--full-auto');
-    } else {
-      args.push('--full-auto', '--cd', shellQuote(options.workingDirectory));
-    }
-
-    // Add model flag if provided
-    if (options.model) {
-      args.push('--model', shellQuote(options.model));
-    }
-
-    return args;
-  }
 }

--- a/packages/smithy/src/providers/codex/interactive.ts
+++ b/packages/smithy/src/providers/codex/interactive.ts
@@ -26,6 +26,42 @@ type CodexInteractiveArgOptions = Pick<
   'resumeSessionId' | 'workingDirectory' | 'model'
 >;
 
+const CODEX_RESUME_SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const CODEX_CONTINUE_SESSION_PATTERN =
+  /To continue this session,\s+run\s+codex\s+resume\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i;
+const ANSI_ESCAPE_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const MAX_CODEX_OUTPUT_BUFFER = 4096;
+
+export function isCodexResumeSessionId(value: string): value is ProviderSessionId {
+  return CODEX_RESUME_SESSION_ID_PATTERN.test(value);
+}
+
+export function extractCodexResumeSessionId(output: string): ProviderSessionId | undefined {
+  const normalizedOutput = output.replace(ANSI_ESCAPE_PATTERN, '');
+  return normalizedOutput.match(CODEX_CONTINUE_SESSION_PATTERN)?.[1];
+}
+
+export function createCodexResumeSessionIdDetector(
+  maxBufferLength = MAX_CODEX_OUTPUT_BUFFER,
+): (chunk: string) => ProviderSessionId | undefined {
+  let buffer = '';
+
+  return (chunk: string) => {
+    buffer = (buffer + chunk).slice(-maxBufferLength);
+    return extractCodexResumeSessionId(buffer);
+  };
+}
+
+export function writeCodexExitCommand(
+  write: (data: string) => void,
+  scheduleEnter: (callback: () => void) => void = (callback) => {
+    setTimeout(callback, 50);
+  },
+): void {
+  write('/exit');
+  scheduleEnter(() => write('\r'));
+}
+
 export function buildCodexInteractiveArgs(
   options: CodexInteractiveArgOptions,
   platform: NodeJS.Platform = process.platform,
@@ -34,6 +70,9 @@ export function buildCodexInteractiveArgs(
   const args: string[] = [];
 
   if (options.resumeSessionId) {
+    if (!isCodexResumeSessionId(options.resumeSessionId)) {
+      throw new Error(`Invalid Codex resume session ID: ${options.resumeSessionId}`);
+    }
     args.push('resume', quote(options.resumeSessionId), '--sandbox', 'workspace-write');
   } else {
     args.push('--sandbox', 'workspace-write', '--cd', quote(options.workingDirectory));
@@ -53,14 +92,16 @@ export function buildCodexInteractiveArgs(
 class CodexInteractiveSession implements InteractiveSession {
   private ptyProcess: IPty;
   private sessionId: ProviderSessionId | undefined;
+  private readonly detectResumeSessionId = createCodexResumeSessionIdDetector();
 
   readonly pid?: number;
 
-  constructor(ptyProcess: IPty) {
+  constructor(ptyProcess: IPty, resumeSessionId?: ProviderSessionId) {
     this.ptyProcess = ptyProcess;
     this.pid = ptyProcess.pid;
+    this.sessionId = resumeSessionId;
 
-    // Listen for thread/session ID in output and auto-respond to terminal queries.
+    // Listen for Codex's continuation footer and auto-respond to terminal queries.
     // Codex sends DSR (Device Status Report) \x1b[6n on startup to query cursor
     // position. When no terminal emulator (e.g. xterm.js) is connected to respond,
     // codex times out and exits. We auto-respond with a default cursor position
@@ -71,9 +112,9 @@ class CodexInteractiveSession implements InteractiveSession {
       }
 
       if (!this.sessionId) {
-        const match = data.match(/(?:Thread|Session|thr_)[:=\s]*([a-z0-9_-]+)/i);
-        if (match) {
-          this.sessionId = match[1];
+        const detectedSessionId = this.detectResumeSessionId(data);
+        if (detectedSessionId) {
+          this.sessionId = detectedSessionId;
         }
       }
     });
@@ -81,6 +122,10 @@ class CodexInteractiveSession implements InteractiveSession {
 
   write(data: string): void {
     this.ptyProcess.write(data);
+  }
+
+  requestExit(): void {
+    writeCodexExitCommand((data) => this.ptyProcess.write(data));
   }
 
   resize(cols: number, rows: number): void {
@@ -156,7 +201,10 @@ export class CodexInteractiveProvider implements InteractiveProvider {
       env,
     });
 
-    const session = new CodexInteractiveSession(ptyProcess);
+    const resumeSessionId = options.resumeSessionId && isCodexResumeSessionId(options.resumeSessionId)
+      ? options.resumeSessionId
+      : undefined;
+    const session = new CodexInteractiveSession(ptyProcess, resumeSessionId);
 
     // On Windows, write the command to cmd.exe stdin (bash -c handles this on Unix)
     if (process.platform === 'win32') {

--- a/packages/smithy/src/providers/codex/provider.bun.test.ts
+++ b/packages/smithy/src/providers/codex/provider.bun.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
 import type { CodexClient, CodexModelInfo } from './server-manager.js';
+import { buildCodexInteractiveArgs } from './interactive.js';
 import { posixShellQuote, shellQuote } from '../shell-quote.js';
 
 // ---------------------------------------------------------------------------
@@ -204,68 +205,53 @@ describe('CodexHeadlessProvider model passthrough', () => {
 // ---------------------------------------------------------------------------
 
 describe('CodexInteractiveProvider model flag', () => {
-  // Use the POSIX form directly so assertions are deterministic regardless of
-  // the host OS the tests run on. A separate suite below covers the Windows
-  // quoter.
-  function buildArgs(options: {
-    resumeSessionId?: string;
-    workingDirectory: string;
-    model?: string;
-  }): string[] {
-    const shellQuote = posixShellQuote;
-    const args: string[] = [];
-
-    if (options.resumeSessionId) {
-      args.push('resume', shellQuote(options.resumeSessionId), '--full-auto');
-    } else {
-      args.push('--full-auto', '--cd', shellQuote(options.workingDirectory));
-    }
-
-    // Add model flag if provided
-    if (options.model) {
-      args.push('--model', shellQuote(options.model));
-    }
-
-    return args;
-  }
-
-  it('should include --model flag when model is provided', () => {
-    const args = buildArgs({
+  it('builds interactive spawn args with the documented workspace-write sandbox', () => {
+    const args = buildCodexInteractiveArgs({
       workingDirectory: '/workspace',
       model: 'gpt-4o',
-    });
+    }, 'linux');
+
+    expect(args).toEqual(['--sandbox', 'workspace-write', '--cd', "'/workspace'", '--model', "'gpt-4o'"]);
+  });
+
+  it('should include --model flag when model is provided', () => {
+    const args = buildCodexInteractiveArgs({
+      workingDirectory: '/workspace',
+      model: 'gpt-4o',
+    }, 'linux');
 
     expect(args).toContain('--model');
     expect(args).toContain("'gpt-4o'");
-    expect(args).toEqual(['--full-auto', '--cd', "'/workspace'", '--model', "'gpt-4o'"]);
+    expect(args).toEqual(['--sandbox', 'workspace-write', '--cd', "'/workspace'", '--model', "'gpt-4o'"]);
   });
 
   it('should not include --model flag when model is undefined', () => {
-    const args = buildArgs({
+    const args = buildCodexInteractiveArgs({
       workingDirectory: '/workspace',
-    });
+    }, 'linux');
 
     expect(args).not.toContain('--model');
-    expect(args).toEqual(['--full-auto', '--cd', "'/workspace'"]);
+    expect(args).toEqual(['--sandbox', 'workspace-write', '--cd', "'/workspace'"]);
   });
 
   it('should include --model flag when resuming with model', () => {
-    const args = buildArgs({
+    const args = buildCodexInteractiveArgs({
       resumeSessionId: 'thr_abc123',
       workingDirectory: '/workspace',
       model: 'o3-mini',
-    });
+    }, 'linux');
 
     expect(args).toContain('resume');
     expect(args).toContain('--model');
     expect(args).toContain("'o3-mini'");
+    expect(args).toEqual(['resume', "'thr_abc123'", '--sandbox', 'workspace-write', '--model', "'o3-mini'"]);
   });
 
   it('should properly quote model names with special characters', () => {
-    const args = buildArgs({
+    const args = buildCodexInteractiveArgs({
       workingDirectory: '/workspace',
       model: "model's-name",
-    });
+    }, 'linux');
 
     expect(args).toContain("--model");
     expect(args).toContain("'model'\\''s-name'");

--- a/packages/smithy/src/providers/codex/provider.bun.test.ts
+++ b/packages/smithy/src/providers/codex/provider.bun.test.ts
@@ -6,7 +6,13 @@
 
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
 import type { CodexClient, CodexModelInfo } from './server-manager.js';
-import { buildCodexInteractiveArgs } from './interactive.js';
+import {
+  buildCodexInteractiveArgs,
+  createCodexResumeSessionIdDetector,
+  extractCodexResumeSessionId,
+  isCodexResumeSessionId,
+  writeCodexExitCommand,
+} from './interactive.js';
 import { posixShellQuote, shellQuote } from '../shell-quote.js';
 
 // ---------------------------------------------------------------------------
@@ -205,6 +211,8 @@ describe('CodexHeadlessProvider model passthrough', () => {
 // ---------------------------------------------------------------------------
 
 describe('CodexInteractiveProvider model flag', () => {
+  const codexSessionId = '019e1277-6206-74e1-bb66-bbd8e9534628';
+
   it('builds interactive spawn args with the documented workspace-write sandbox', () => {
     const args = buildCodexInteractiveArgs({
       workingDirectory: '/workspace',
@@ -236,7 +244,7 @@ describe('CodexInteractiveProvider model flag', () => {
 
   it('should include --model flag when resuming with model', () => {
     const args = buildCodexInteractiveArgs({
-      resumeSessionId: 'thr_abc123',
+      resumeSessionId: codexSessionId,
       workingDirectory: '/workspace',
       model: 'o3-mini',
     }, 'linux');
@@ -244,7 +252,14 @@ describe('CodexInteractiveProvider model flag', () => {
     expect(args).toContain('resume');
     expect(args).toContain('--model');
     expect(args).toContain("'o3-mini'");
-    expect(args).toEqual(['resume', "'thr_abc123'", '--sandbox', 'workspace-write', '--model', "'o3-mini'"]);
+    expect(args).toEqual(['resume', `'${codexSessionId}'`, '--sandbox', 'workspace-write', '--model', "'o3-mini'"]);
+  });
+
+  it('should reject non-UUID resume session IDs', () => {
+    expect(() => buildCodexInteractiveArgs({
+      resumeSessionId: 'thr_abc123',
+      workingDirectory: '/workspace',
+    }, 'linux')).toThrow('Invalid Codex resume session ID');
   });
 
   it('should properly quote model names with special characters', () => {
@@ -255,6 +270,62 @@ describe('CodexInteractiveProvider model flag', () => {
 
     expect(args).toContain("--model");
     expect(args).toContain("'model'\\''s-name'");
+  });
+});
+
+describe('Codex interactive resume session ID parsing', () => {
+  const codexSessionId = '019e1277-6206-74e1-bb66-bbd8e9534628';
+
+  it('extracts UUID from Codex continuation footer', () => {
+    expect(extractCodexResumeSessionId(
+      `Token usage: total=19,927\nTo continue this session, run codex resume ${codexSessionId}\n`,
+    )).toBe(codexSessionId);
+  });
+
+  it('ignores ordinary session management text', () => {
+    expect(extractCodexResumeSessionId('Agent Session Management')).toBeUndefined();
+  });
+
+  it('ignores Codex session-not-found errors', () => {
+    expect(extractCodexResumeSessionId(
+      'No saved session found with ID management. Run `codex resume` without an ID to choose from existing sessions.',
+    )).toBeUndefined();
+  });
+
+  it('ignores non-UUID continuation footer values', () => {
+    expect(extractCodexResumeSessionId('To continue this session, run codex resume management')).toBeUndefined();
+  });
+
+  it('detects footer split across PTY chunks', () => {
+    const detect = createCodexResumeSessionIdDetector();
+
+    expect(detect('Token usage: total=19,927\nTo continue this session, ')).toBeUndefined();
+    expect(detect(`run codex resume ${codexSessionId}\n`)).toBe(codexSessionId);
+  });
+
+  it('validates Codex resume IDs as UUIDs', () => {
+    expect(isCodexResumeSessionId(codexSessionId)).toBe(true);
+    expect(isCodexResumeSessionId('management')).toBe(false);
+    expect(isCodexResumeSessionId('thr_abc123')).toBe(false);
+  });
+});
+
+describe('Codex interactive graceful exit', () => {
+  it('writes slash exit and schedules Enter as separate PTY writes', () => {
+    const writes: string[] = [];
+    const scheduled: (() => void)[] = [];
+
+    writeCodexExitCommand(
+      (data) => writes.push(data),
+      (callback) => scheduled.push(callback),
+    );
+
+    expect(writes).toEqual(['/exit']);
+    expect(scheduled).toHaveLength(1);
+
+    scheduled[0]();
+
+    expect(writes).toEqual(['/exit', '\r']);
   });
 });
 

--- a/packages/smithy/src/providers/types.ts
+++ b/packages/smithy/src/providers/types.ts
@@ -124,6 +124,8 @@ export interface InteractiveSession {
   readonly pid?: number;
   /** Write data to the PTY */
   write(data: string): void;
+  /** Request a graceful provider-specific exit, if different from shell exit */
+  requestExit?(): void;
   /** Resize the terminal */
   resize(cols: number, rows: number): void;
   /** Kill the PTY */

--- a/packages/smithy/src/runtime/session-manager.bun.test.ts
+++ b/packages/smithy/src/runtime/session-manager.bun.test.ts
@@ -1229,6 +1229,22 @@ describe('SessionManager', () => {
       expect(updatedSession?.status).toBe('terminated');
     });
 
+    test('onExit notifies session-ended callbacks', async () => {
+      const endedSessionIds: string[] = [];
+      sessionManager.onSessionEnded((endedSession) => {
+        endedSessionIds.push(endedSession.id);
+      });
+
+      const { session } = await sessionManager.startSession(testAgentId);
+
+      const spawnerEmitter = spawner._mockEmitters.get(session.id);
+      spawnerEmitter?.emit('exit', 0, null);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(endedSessionIds).toEqual([session.id]);
+    });
+
     test('onExit does not modify already-terminated sessions', async () => {
       const { session } = await sessionManager.startSession(testAgentId);
       await sessionManager.stopSession(session.id, { reason: 'Explicit stop' });
@@ -1260,6 +1276,11 @@ describe('SessionManager', () => {
     });
 
     test('listSessions excludes sessions with dead PIDs', async () => {
+      const endedSessionIds: string[] = [];
+      sessionManager.onSessionEnded((endedSession) => {
+        endedSessionIds.push(endedSession.id);
+      });
+
       const { session } = await sessionManager.startSession(testAgentId);
 
       // Manually set a dead PID on the session to simulate a crashed process
@@ -1276,6 +1297,7 @@ describe('SessionManager', () => {
       const allSessions = sessionManager.listSessions({ status: 'terminated' });
       expect(allSessions).toHaveLength(1);
       expect(allSessions[0].terminationReason).toContain('Process no longer alive');
+      expect(endedSessionIds).toEqual([session.id]);
     });
 
     test('listSessions cleans up starting sessions with dead PIDs', async () => {

--- a/packages/smithy/src/runtime/session-manager.bun.test.ts
+++ b/packages/smithy/src/runtime/session-manager.bun.test.ts
@@ -1245,6 +1245,42 @@ describe('SessionManager', () => {
       expect(endedSessionIds).toEqual([session.id]);
     });
 
+    test('startSession waits for prior session-ended callbacks for the same agent', async () => {
+      let releaseCallback: (() => void) | undefined;
+      let callbackStarted = false;
+      let callbackFinished = false;
+      sessionManager.onSessionEnded(async () => {
+        callbackStarted = true;
+        await new Promise<void>((resolve) => {
+          releaseCallback = resolve;
+        });
+        callbackFinished = true;
+      });
+
+      const { session: firstSession } = await sessionManager.startSession(testAgentId);
+      spawner._mockEmitters.get(firstSession.id)?.emit('exit', 0, null);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(callbackStarted).toBe(true);
+
+      const secondStart = sessionManager.startSession(testAgentId);
+      let secondStarted = false;
+      secondStart.then(() => {
+        secondStarted = true;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(secondStarted).toBe(false);
+      expect(callbackFinished).toBe(false);
+
+      releaseCallback?.();
+      const { session: secondSession } = await secondStart;
+
+      expect(callbackFinished).toBe(true);
+      expect(secondStarted).toBe(true);
+      expect(secondSession.id).not.toBe(firstSession.id);
+    });
+
     test('onExit does not modify already-terminated sessions', async () => {
       const { session } = await sessionManager.startSession(testAgentId);
       await sessionManager.stopSession(session.id, { reason: 'Explicit stop' });

--- a/packages/smithy/src/runtime/session-manager.ts
+++ b/packages/smithy/src/runtime/session-manager.ts
@@ -505,6 +505,7 @@ export class SessionManagerImpl implements SessionManager {
   private readonly sessionHistory: Map<EntityId, SessionHistoryEntry[]> = new Map();
   private readonly sessionCleanupFns: Map<string, () => void> = new Map(); // sessionId -> cleanup function
   private readonly sessionEndedCallbacks: Set<SessionEndedCallback> = new Set();
+  private readonly sessionEndCleanupPromises: Map<EntityId, Promise<void>> = new Map();
 
   private operationLog: OperationLogService | undefined;
 
@@ -548,6 +549,8 @@ export class SessionManagerImpl implements SessionManager {
     agentId: EntityId,
     options?: StartSessionOptions
   ): Promise<{ session: SessionRecord; events: EventEmitter }> {
+    await this.waitForSessionEndCleanup(agentId);
+
     // Get agent to determine role and mode
     const agent = await this.registry.getAgent(agentId);
     if (!agent) {
@@ -639,6 +642,8 @@ export class SessionManagerImpl implements SessionManager {
     agentId: EntityId,
     options: ResumeSessionOptions
   ): Promise<{ session: SessionRecord; events: EventEmitter; uwpCheck?: ResumeUWPCheckResult }> {
+    await this.waitForSessionEndCleanup(agentId);
+
     // Get agent to determine role and mode
     const agent = await this.registry.getAgent(agentId);
     if (!agent) {
@@ -803,7 +808,7 @@ export class SessionManagerImpl implements SessionManager {
 
     // Emit status change
     finalSession.events.emit('status', 'terminated');
-    this.notifySessionEnded(finalSession);
+    await this.notifySessionEnded(finalSession);
 
     // Log session termination
     this.operationLog?.write('info', 'session', `Session terminated for agent ${session.agentId}${options?.reason ? `: ${options.reason}` : ''}`, { agentId: session.agentId, sessionId });
@@ -873,7 +878,7 @@ export class SessionManagerImpl implements SessionManager {
 
     // Emit status change
     updatedSession.events.emit('status', 'suspended');
-    this.notifySessionEnded(updatedSession);
+    await this.notifySessionEnded(updatedSession);
   }
 
   // ----------------------------------------
@@ -1429,7 +1434,7 @@ export class SessionManagerImpl implements SessionManager {
     this.persistSession(session.id).then(() => {
       this.scheduleTerminatedSessionCleanup(session.id);
     }).catch(() => {});
-    this.notifySessionEnded(updated);
+    void this.notifySessionEnded(updated);
   }
 
   private setupSpawnerEventHandlers(): void {
@@ -1549,7 +1554,7 @@ export class SessionManagerImpl implements SessionManager {
         this.scheduleTerminatedSessionCleanup(session.id);
 
         updatedSession.events.emit('status', 'terminated');
-        this.notifySessionEnded(updatedSession);
+        await this.notifySessionEnded(updatedSession);
       } else {
         console.log(`[session-manager] Session ${session.id} already in status: ${currentSession?.status ?? 'not found'}`);
       }
@@ -1600,19 +1605,44 @@ export class SessionManagerImpl implements SessionManager {
     }
   }
 
-  private notifySessionEnded(session: InternalSessionState): void {
-    if (this.sessionEndedCallbacks.size === 0) return;
-
-    const publicSession = this.toPublicSession(session);
-    for (const callback of this.sessionEndedCallbacks) {
-      Promise.resolve(callback(publicSession)).catch((error) => {
-        this.operationLog?.write('warn', 'session', `Session ended callback failed for ${session.id}`, {
-          agentId: session.agentId,
-          sessionId: session.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
+  private async waitForSessionEndCleanup(agentId: EntityId): Promise<void> {
+    const cleanup = this.sessionEndCleanupPromises.get(agentId);
+    if (cleanup) {
+      await cleanup;
     }
+  }
+
+  private notifySessionEnded(session: InternalSessionState): Promise<void> {
+    const previousCleanup = this.sessionEndCleanupPromises.get(session.agentId) ?? Promise.resolve();
+    const runCallbacks = async () => {
+      if (this.sessionEndedCallbacks.size === 0) return;
+
+      const publicSession = this.toPublicSession(session);
+      await Promise.all(Array.from(this.sessionEndedCallbacks, async (callback) => {
+        try {
+          await callback(publicSession);
+        } catch (error) {
+          this.operationLog?.write('warn', 'session', `Session ended callback failed for ${session.id}`, {
+            agentId: session.agentId,
+            sessionId: session.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }));
+    };
+
+    const cleanup = this.sessionEndCleanupPromises.has(session.agentId)
+      ? previousCleanup.then(runCallbacks)
+      : runCallbacks();
+
+    const trackedCleanup = cleanup.finally(() => {
+      if (this.sessionEndCleanupPromises.get(session.agentId) === trackedCleanup) {
+        this.sessionEndCleanupPromises.delete(session.agentId);
+      }
+    });
+
+    this.sessionEndCleanupPromises.set(session.agentId, trackedCleanup);
+    return trackedCleanup;
   }
 
   private createSessionState(

--- a/packages/smithy/src/runtime/session-manager.ts
+++ b/packages/smithy/src/runtime/session-manager.ts
@@ -137,6 +137,8 @@ export interface StopSessionOptions {
   readonly reason?: string;
 }
 
+export type SessionEndedCallback = (session: SessionRecord) => void | Promise<void>;
+
 /**
  * Options for sending a message to a session
  */
@@ -464,6 +466,14 @@ export interface SessionManager {
    * Called after construction to avoid circular dependency issues.
    */
   setOperationLog(log: OperationLogService): void;
+
+  /**
+   * Registers a callback for sessions leaving active execution.
+   *
+   * @param callback - Called when a session is terminated or suspended
+   * @returns Function to remove the callback
+   */
+  onSessionEnded(callback: SessionEndedCallback): () => void;
 }
 
 // ============================================================================
@@ -494,6 +504,7 @@ export class SessionManagerImpl implements SessionManager {
   private readonly agentSessions: Map<EntityId, string> = new Map(); // agentId -> active sessionId
   private readonly sessionHistory: Map<EntityId, SessionHistoryEntry[]> = new Map();
   private readonly sessionCleanupFns: Map<string, () => void> = new Map(); // sessionId -> cleanup function
+  private readonly sessionEndedCallbacks: Set<SessionEndedCallback> = new Set();
 
   private operationLog: OperationLogService | undefined;
 
@@ -520,6 +531,13 @@ export class SessionManagerImpl implements SessionManager {
    */
   setOperationLog(log: OperationLogService): void {
     this.operationLog = log;
+  }
+
+  onSessionEnded(callback: SessionEndedCallback): () => void {
+    this.sessionEndedCallbacks.add(callback);
+    return () => {
+      this.sessionEndedCallbacks.delete(callback);
+    };
   }
 
   // ----------------------------------------
@@ -785,6 +803,7 @@ export class SessionManagerImpl implements SessionManager {
 
     // Emit status change
     finalSession.events.emit('status', 'terminated');
+    this.notifySessionEnded(finalSession);
 
     // Log session termination
     this.operationLog?.write('info', 'session', `Session terminated for agent ${session.agentId}${options?.reason ? `: ${options.reason}` : ''}`, { agentId: session.agentId, sessionId });
@@ -854,6 +873,7 @@ export class SessionManagerImpl implements SessionManager {
 
     // Emit status change
     updatedSession.events.emit('status', 'suspended');
+    this.notifySessionEnded(updatedSession);
   }
 
   // ----------------------------------------
@@ -1409,6 +1429,7 @@ export class SessionManagerImpl implements SessionManager {
     this.persistSession(session.id).then(() => {
       this.scheduleTerminatedSessionCleanup(session.id);
     }).catch(() => {});
+    this.notifySessionEnded(updated);
   }
 
   private setupSpawnerEventHandlers(): void {
@@ -1528,6 +1549,7 @@ export class SessionManagerImpl implements SessionManager {
         this.scheduleTerminatedSessionCleanup(session.id);
 
         updatedSession.events.emit('status', 'terminated');
+        this.notifySessionEnded(updatedSession);
       } else {
         console.log(`[session-manager] Session ${session.id} already in status: ${currentSession?.status ?? 'not found'}`);
       }
@@ -1575,6 +1597,21 @@ export class SessionManagerImpl implements SessionManager {
       cleanup();
       this.sessionCleanupFns.delete(sessionId);
       console.log(`[session-manager] Cleaned up event listeners for session ${sessionId}`);
+    }
+  }
+
+  private notifySessionEnded(session: InternalSessionState): void {
+    if (this.sessionEndedCallbacks.size === 0) return;
+
+    const publicSession = this.toPublicSession(session);
+    for (const callback of this.sessionEndedCallbacks) {
+      Promise.resolve(callback(publicSession)).catch((error) => {
+        this.operationLog?.write('warn', 'session', `Session ended callback failed for ${session.id}`, {
+          agentId: session.agentId,
+          sessionId: session.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     }
   }
 

--- a/packages/smithy/src/runtime/session-manager.ts
+++ b/packages/smithy/src/runtime/session-manager.ts
@@ -746,9 +746,6 @@ export class SessionManagerImpl implements SessionManager {
       throw new Error(`Session not found: ${sessionId}`);
     }
 
-    // Clean up event listeners to prevent leaks
-    this.cleanupSessionEventListeners(sessionId);
-
     // Update session state BEFORE terminating to prevent race with exit event handler
     const updatedSession: InternalSessionState = {
       ...session,
@@ -764,11 +761,18 @@ export class SessionManagerImpl implements SessionManager {
       this.agentSessions.delete(session.agentId);
     }
 
-    // Add to history (do this before terminate to avoid race with exit handler)
-    this.addToHistory(session.agentId, updatedSession);
-
-    // Now terminate via spawner (may trigger exit event, but status already terminated)
+    // Now terminate via spawner (may trigger exit/provider-session-id events, but status already terminated).
+    // Keep listeners attached until this completes so provider-specific graceful shutdown output
+    // can still update providerSessionId before the session is added to history.
     await this.spawner.terminate(sessionId, options?.graceful ?? true);
+
+    const finalSession = this.sessions.get(sessionId) ?? updatedSession;
+
+    // Clean up event listeners after graceful termination output has been observed.
+    this.cleanupSessionEventListeners(sessionId);
+
+    // Add to history after terminate so providerSessionId captured during shutdown is included.
+    this.addToHistory(session.agentId, finalSession);
 
     // Update agent's session status in database
     await this.registry.updateAgentSession(session.agentId, undefined, 'idle');
@@ -780,7 +784,7 @@ export class SessionManagerImpl implements SessionManager {
     this.scheduleTerminatedSessionCleanup(sessionId);
 
     // Emit status change
-    session.events.emit('status', 'terminated');
+    finalSession.events.emit('status', 'terminated');
 
     // Log session termination
     this.operationLog?.write('info', 'session', `Session terminated for agent ${session.agentId}${options?.reason ? `: ${options.reason}` : ''}`, { agentId: session.agentId, sessionId });

--- a/packages/smithy/src/runtime/spawner.bun.test.ts
+++ b/packages/smithy/src/runtime/spawner.bun.test.ts
@@ -102,6 +102,61 @@ describe('SpawnerService', () => {
         'Session not found'
       );
     });
+
+    test('uses provider-specific requestExit for graceful interactive termination', async () => {
+      let exitCallback: ((code: number, signal?: number) => void) | undefined;
+      const writes: string[] = [];
+
+      const interactiveProvider: InteractiveProvider = {
+        name: 'mock-interactive',
+        spawn: async (): Promise<InteractiveSession> => ({
+          pid: 12345,
+          write: (data: string) => {
+            writes.push(data);
+          },
+          requestExit: () => {
+            writes.push('requestExit');
+            exitCallback?.(0);
+          },
+          resize: () => {},
+          kill: () => {
+            writes.push('kill');
+          },
+          onData: () => {},
+          onExit: (callback: (code: number, signal?: number) => void) => {
+            exitCallback = callback;
+          },
+          getSessionId: () => undefined,
+        }),
+        isAvailable: async () => true,
+      };
+
+      const provider: AgentProvider = {
+        name: 'mock-provider',
+        headless: createMockHeadlessProvider(createImmediateExitHeadlessSession),
+        interactive: interactiveProvider,
+        isAvailable: async () => true,
+        getInstallInstructions: () => 'No install needed for mock',
+        listModels: async (): Promise<ModelInfo[]> => [],
+      };
+
+      const service = new SpawnerServiceImpl({
+        provider,
+        workingDirectory: '/tmp',
+        timeout: 1000,
+      });
+
+      const result = await service.spawn(testAgentId, 'director', {
+        mode: 'interactive',
+      });
+
+      await service.terminate(result.session.id, true);
+
+      expect(writes).toContain('requestExit');
+      expect(writes).not.toContain('exit\r');
+      expect(writes).not.toContain('kill');
+      expect(service.getSession(result.session.id)?.status).toBe('terminated');
+    });
   });
 
   describe('suspend', () => {

--- a/packages/smithy/src/runtime/spawner.ts
+++ b/packages/smithy/src/runtime/spawner.ts
@@ -584,7 +584,11 @@ export class SpawnerServiceImpl implements SpawnerService {
     // Handle provider interactive sessions
     if (session.interactiveSession) {
       if (graceful) {
-        session.interactiveSession.write('exit\r');
+        if (session.interactiveSession.requestExit) {
+          session.interactiveSession.requestExit();
+        } else {
+          session.interactiveSession.write('exit\r');
+        }
 
         await new Promise<void>((resolve) => {
           const timeout = setTimeout(() => {

--- a/packages/smithy/src/server/routes/sessions.ts
+++ b/packages/smithy/src/server/routes/sessions.ts
@@ -21,6 +21,7 @@ import { notifySSEClientsOfNewSession } from './events.js';
 import { createLogger } from '../../utils/logger.js';
 
 const logger = createLogger('sessions');
+const CODEX_RESUME_SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 type NotifyClientsCallback = (
   agentId: EntityId,
@@ -603,6 +604,17 @@ Please begin working on this task. Use \`sf task get ${taskResult.id}\` to see f
           return c.json({ error: { code: 'NO_RESUMABLE_SESSION', message: 'No resumable session found' } }, 404);
         }
         providerSessionId = resumable.providerSessionId;
+      }
+
+      const meta = getAgentMetadata(agent);
+      if ((meta as { provider?: string } | undefined)?.provider === 'codex'
+        && !CODEX_RESUME_SESSION_ID_PATTERN.test(providerSessionId)) {
+        return c.json({
+          error: {
+            code: 'INVALID_PROVIDER_SESSION_ID',
+            message: 'Codex resume requires a valid UUID session ID',
+          },
+        }, 400);
       }
 
       const { session, events, uwpCheck } = await sessionManager.resumeSession(agentId, {

--- a/packages/smithy/src/server/services.ts
+++ b/packages/smithy/src/server/services.ts
@@ -272,6 +272,10 @@ export async function initializeServices(options: ServicesOptions = {}): Promise
 
   // Create pool service for agent concurrency limiting
   const poolService = createAgentPoolService(api, sessionManager, agentRegistry);
+  sessionManager.onSessionEnded((session) => {
+    if (session.agentRole === 'director') return;
+    return poolService.onAgentSessionEnded(session.agentId);
+  });
 
   const inboxService = createInboxService(storageBackend);
   const sessionMessageService = createSessionMessageService(storageBackend);

--- a/packages/smithy/src/services/agent-pool-service.bun.test.ts
+++ b/packages/smithy/src/services/agent-pool-service.bun.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Agent Pool Service Tests
+ *
+ * Covers pool slot accounting for spawned and ended agent sessions.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import { createStorage, initializeSchema } from '@stoneforge/storage';
+import { createQuarryAPI, type QuarryAPI } from '@stoneforge/quarry';
+import { type EntityId, type ElementId, createEntity, EntityTypeValue } from '@stoneforge/core';
+import type { SessionManager } from '../runtime/session-manager.js';
+import { createAgentRegistry, type AgentRegistry } from './agent-registry.js';
+import { createAgentPoolService, type AgentPoolService } from './agent-pool-service.js';
+
+describe('AgentPoolService', () => {
+  let api: QuarryAPI;
+  let agentRegistry: AgentRegistry;
+  let poolService: AgentPoolService;
+  let testDbPath: string;
+  let systemEntity: EntityId;
+
+  beforeEach(async () => {
+    testDbPath = `/tmp/agent-pool-service-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+    const storage = createStorage(testDbPath);
+    initializeSchema(storage);
+
+    api = createQuarryAPI(storage);
+    agentRegistry = createAgentRegistry(api);
+    poolService = createAgentPoolService(
+      api,
+      { listSessions: () => [] } as unknown as SessionManager,
+      agentRegistry
+    );
+
+    const entity = await createEntity({
+      name: 'test-system',
+      entityType: EntityTypeValue.SYSTEM,
+      createdBy: 'system:test' as EntityId,
+    });
+    const saved = await api.create(entity as unknown as Record<string, unknown> & { createdBy: EntityId });
+    systemEntity = saved.id as unknown as EntityId;
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testDbPath)) {
+      fs.unlinkSync(testDbPath);
+    }
+  });
+
+  test('does not release a pool slot for a matching agent that was not occupying it', async () => {
+    const pool = await poolService.createPool({
+      name: 'ephemeral_workers',
+      maxSize: 1,
+      agentTypes: [{ role: 'worker', workerMode: 'ephemeral' }],
+      createdBy: systemEntity,
+    });
+
+    const activeWorker = await agentRegistry.registerWorker({
+      name: 'active-worker',
+      workerMode: 'ephemeral',
+      createdBy: systemEntity,
+    });
+    const idleWorker = await agentRegistry.registerWorker({
+      name: 'idle-worker',
+      workerMode: 'ephemeral',
+      createdBy: systemEntity,
+    });
+
+    await poolService.onAgentSpawned(activeWorker.id as unknown as EntityId);
+    await poolService.onAgentSessionEnded(idleWorker.id as unknown as EntityId);
+
+    const status = await poolService.getPoolStatus(pool.id as ElementId);
+    expect(status.activeCount).toBe(1);
+    expect(status.availableSlots).toBe(0);
+    expect(status.activeAgentIds).toEqual([activeWorker.id]);
+  });
+});

--- a/packages/smithy/src/services/agent-pool-service.bun.test.ts
+++ b/packages/smithy/src/services/agent-pool-service.bun.test.ts
@@ -67,12 +67,35 @@ describe('AgentPoolService', () => {
       createdBy: systemEntity,
     });
 
-    await poolService.onAgentSpawned(activeWorker.id as unknown as EntityId);
+    await poolService.onAgentSessionStarting(activeWorker.id as unknown as EntityId);
     await poolService.onAgentSessionEnded(idleWorker.id as unknown as EntityId);
 
     const status = await poolService.getPoolStatus(pool.id as ElementId);
     expect(status.activeCount).toBe(1);
     expect(status.availableSlots).toBe(0);
     expect(status.activeAgentIds).toEqual([activeWorker.id]);
+  });
+
+  test('does not double-count an agent whose pool slot is already reserved', async () => {
+    const pool = await poolService.createPool({
+      name: 'deduped_ephemeral_workers',
+      maxSize: 2,
+      agentTypes: [{ role: 'worker', workerMode: 'ephemeral' }],
+      createdBy: systemEntity,
+    });
+
+    const worker = await agentRegistry.registerWorker({
+      name: 'deduped-worker',
+      workerMode: 'ephemeral',
+      createdBy: systemEntity,
+    });
+
+    await poolService.onAgentSessionStarting(worker.id as unknown as EntityId);
+    await poolService.onAgentSessionStarting(worker.id as unknown as EntityId);
+
+    const status = await poolService.getPoolStatus(pool.id as ElementId);
+    expect(status.activeCount).toBe(1);
+    expect(status.availableSlots).toBe(1);
+    expect(status.activeAgentIds).toEqual([worker.id]);
   });
 });

--- a/packages/smithy/src/services/agent-pool-service.ts
+++ b/packages/smithy/src/services/agent-pool-service.ts
@@ -702,6 +702,10 @@ export class AgentPoolServiceImpl implements AgentPoolService {
     // Update status for each pool
     for (const pool of pools) {
       const status = this.statusCache.get(pool.id) ?? await this.getPoolStatus(pool.id);
+      if (!status.activeAgentIds.includes(agentId)) {
+        continue;
+      }
+
       const typeKey = this.getAgentTypeKey(agent);
 
       const updatedStatus: AgentPoolStatus = {

--- a/packages/smithy/src/services/agent-pool-service.ts
+++ b/packages/smithy/src/services/agent-pool-service.ts
@@ -184,8 +184,19 @@ export interface AgentPoolService {
   // ----------------------------------------
 
   /**
+   * Notifies the service that an agent session is starting.
+   * Updates pool status accordingly.
+   *
+   * @param agentId - The starting agent ID
+   */
+  onAgentSessionStarting(agentId: EntityId): Promise<void>;
+
+  /**
    * Notifies the service that an agent has been spawned.
    * Updates pool status accordingly.
+   *
+   * @deprecated Use onAgentSessionStarting so pool occupancy is reserved before
+   * the provider process can exit.
    *
    * @param agentId - The spawned agent ID
    */
@@ -622,7 +633,7 @@ export class AgentPoolServiceImpl implements AgentPoolService {
   // Agent Tracking
   // ----------------------------------------
 
-  async onAgentSpawned(agentId: EntityId): Promise<void> {
+  async onAgentSessionStarting(agentId: EntityId): Promise<void> {
     // Get agent details
     const agent = await this.agentRegistry.getAgent(agentId);
     if (!agent) {
@@ -649,6 +660,10 @@ export class AgentPoolServiceImpl implements AgentPoolService {
     // Update status for each pool
     for (const pool of pools) {
       const status = this.statusCache.get(pool.id) ?? await this.getPoolStatus(pool.id);
+      if (status.activeAgentIds.includes(agentId)) {
+        continue;
+      }
+
       const typeKey = this.getAgentTypeKey(agent);
 
       const updatedStatus: AgentPoolStatus = {
@@ -664,6 +679,10 @@ export class AgentPoolServiceImpl implements AgentPoolService {
 
       this.statusCache.set(pool.id, updatedStatus);
     }
+  }
+
+  async onAgentSpawned(agentId: EntityId): Promise<void> {
+    return this.onAgentSessionStarting(agentId);
   }
 
   async onAgentSessionEnded(agentId: EntityId): Promise<void> {

--- a/packages/smithy/src/services/dispatch-daemon.bun.test.ts
+++ b/packages/smithy/src/services/dispatch-daemon.bun.test.ts
@@ -45,6 +45,7 @@ import type { SettingsService, ServerAgentDefaults } from './settings-service.js
 import { createAgentRegistry, getAgentMetadata, type AgentRegistry, type AgentEntity } from './agent-registry.js';
 import { createTaskAssignmentService, type TaskAssignmentService } from './task-assignment-service.js';
 import { createDispatchService, type DispatchService } from './dispatch-service.js';
+import type { AgentPoolService } from './agent-pool-service.js';
 import type { SessionManager, SessionRecord, StartSessionOptions } from '../runtime/session-manager.js';
 import type { WorktreeManager, CreateWorktreeResult, CreateWorktreeOptions } from '../git/worktree-manager.js';
 import type { StewardScheduler } from './steward-scheduler.js';
@@ -270,6 +271,110 @@ describe('DispatchDaemon Integration', () => {
           workingDirectory: expect.stringContaining('worktrees'),
         })
       );
+    });
+
+    test('records pool occupancy before starting a worker session', async () => {
+      const callOrder: string[] = [];
+      const worker = await createTestWorker('pool-worker');
+      await createTestTask('Task for pool worker');
+
+      const poolService = {
+        canSpawn: mock(async () => ({ canSpawn: true })),
+        onAgentSessionStarting: mock(async () => {
+          callOrder.push('onAgentSessionStarting');
+        }),
+        onAgentSessionEnded: mock(async () => {}),
+      } as unknown as AgentPoolService;
+
+      (sessionManager.startSession as ReturnType<typeof mock>).mockImplementation(
+        async (agentId: EntityId, options?: StartSessionOptions) => {
+          callOrder.push('startSession');
+          const session: SessionRecord = {
+            id: `session-${Date.now()}`,
+            agentId,
+            agentRole: 'worker',
+            workerMode: 'ephemeral',
+            status: 'running',
+            workingDirectory: options?.workingDirectory,
+            worktree: options?.worktree,
+            createdAt: createTimestamp(),
+            startedAt: createTimestamp(),
+            lastActivityAt: createTimestamp(),
+          };
+          return { session, events: new EventEmitter() };
+        }
+      );
+
+      await daemon.stop();
+      daemon = createDispatchDaemon(
+        api,
+        agentRegistry,
+        sessionManager,
+        dispatchService,
+        worktreeManager,
+        taskAssignment,
+        stewardScheduler,
+        inboxService,
+        {
+          ensureTargetBranchExists: mockEnsureTargetBranchExists,
+          pollIntervalMs: 100,
+          workerAvailabilityPollEnabled: true,
+          inboxPollEnabled: true,
+          stewardTriggerPollEnabled: false,
+          workflowTaskPollEnabled: false,
+        },
+        poolService
+      );
+
+      const result = await daemon.pollWorkerAvailability();
+
+      expect(result.processed).toBe(1);
+      expect(callOrder).toEqual(['onAgentSessionStarting', 'startSession']);
+      expect(poolService.onAgentSessionStarting).toHaveBeenCalledWith(worker.id);
+    });
+
+    test('releases reserved pool occupancy when worker session startup fails', async () => {
+      const worker = await createTestWorker('pool-fail-worker');
+      await createTestTask('Task for failed pool worker');
+
+      const poolService = {
+        canSpawn: mock(async () => ({ canSpawn: true })),
+        onAgentSessionStarting: mock(async () => {}),
+        onAgentSessionEnded: mock(async () => {}),
+      } as unknown as AgentPoolService;
+
+      (sessionManager.startSession as ReturnType<typeof mock>).mockImplementation(
+        async () => {
+          throw new Error('provider unavailable');
+        }
+      );
+
+      await daemon.stop();
+      daemon = createDispatchDaemon(
+        api,
+        agentRegistry,
+        sessionManager,
+        dispatchService,
+        worktreeManager,
+        taskAssignment,
+        stewardScheduler,
+        inboxService,
+        {
+          ensureTargetBranchExists: mockEnsureTargetBranchExists,
+          pollIntervalMs: 100,
+          workerAvailabilityPollEnabled: true,
+          inboxPollEnabled: true,
+          stewardTriggerPollEnabled: false,
+          workflowTaskPollEnabled: false,
+        },
+        poolService
+      );
+
+      const result = await daemon.pollWorkerAvailability();
+
+      expect(result.processed).toBe(0);
+      expect(poolService.onAgentSessionStarting).toHaveBeenCalledWith(worker.id);
+      expect(poolService.onAgentSessionEnded).toHaveBeenCalledWith(worker.id);
     });
 
     test('does not dispatch to worker with active session', async () => {

--- a/packages/smithy/src/services/dispatch-daemon.ts
+++ b/packages/smithy/src/services/dispatch-daemon.ts
@@ -790,6 +790,27 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       : this.rateLimitTracker.getAllLimits().length > 0;
   }
 
+  private async reservePoolSlot(agentId: EntityId): Promise<boolean> {
+    if (!this.poolService) {
+      return false;
+    }
+
+    await this.poolService.onAgentSessionStarting(agentId);
+    return true;
+  }
+
+  private async releaseReservedPoolSlot(agentId: EntityId, reserved: boolean): Promise<void> {
+    if (!reserved || !this.poolService) {
+      return;
+    }
+
+    try {
+      await this.poolService.onAgentSessionEnded(agentId);
+    } catch (error) {
+      logger.error(`Failed to release reserved pool slot for agent ${agentId}:`, error);
+    }
+  }
+
   getRateLimitStatus(): {
     isPaused: boolean;
     limits: Array<{ executable: string; resetsAt: string }>;
@@ -2801,15 +2822,24 @@ export class DispatchDaemonImpl implements DispatchDaemon {
     // Build initial prompt with task context
     const initialPrompt = await this.buildTaskPrompt(task, workerId);
 
+    const poolSlotReserved = await this.reservePoolSlot(workerId);
+
     // Spawn worker INSIDE the worktree BEFORE dispatching the task.
     // This ensures that if the session fails to start (e.g. provider not
     // available), the task stays unassigned and available for other agents.
-    const { session, events } = await this.sessionManager.startSession(workerId, {
-      workingDirectory: worktreePath,
-      worktree: worktreePath,
-      initialPrompt,
-      executablePathOverride: executableOverride ?? undefined,
-    });
+    let session: SessionRecord;
+    let events: EventEmitter;
+    try {
+      ({ session, events } = await this.sessionManager.startSession(workerId, {
+        workingDirectory: worktreePath,
+        worktree: worktreePath,
+        initialPrompt,
+        executablePathOverride: executableOverride ?? undefined,
+      }));
+    } catch (error) {
+      await this.releaseReservedPoolSlot(workerId, poolSlotReserved);
+      throw error;
+    }
 
     // Attach event listeners IMMEDIATELY after session start, before any awaits.
     // This prevents a race condition where rate_limited events emitted during
@@ -2899,11 +2929,6 @@ export class DispatchDaemonImpl implements DispatchDaemon {
         finalMetadata = updateOrchestratorTaskMeta(finalMetadata, metaUpdate);
       }
       await this.api.update<Task>(task.id, { metadata: finalMetadata });
-    }
-
-    // Notify pool service that agent was spawned
-    if (this.poolService) {
-      await this.poolService.onAgentSpawned(workerId);
     }
 
     this.emitter.emit('agent:spawned', workerId, worktreePath);
@@ -3319,14 +3344,23 @@ export class DispatchDaemonImpl implements DispatchDaemon {
 
     const workingDirectory = worktreePath;
 
+    const poolSlotReserved = await this.reservePoolSlot(stewardId);
+
     // Start the steward session
-    const { session, events } = await this.sessionManager.startSession(stewardId, {
-      workingDirectory,
-      worktree: worktreePath,
-      initialPrompt,
-      interactive: false, // Stewards use headless mode
-      executablePathOverride: stewardExecutableOverride ?? undefined,
-    });
+    let session: SessionRecord;
+    let events: EventEmitter;
+    try {
+      ({ session, events } = await this.sessionManager.startSession(stewardId, {
+        workingDirectory,
+        worktree: worktreePath,
+        initialPrompt,
+        interactive: false, // Stewards use headless mode
+        executablePathOverride: stewardExecutableOverride ?? undefined,
+      }));
+    } catch (error) {
+      await this.releaseReservedPoolSlot(stewardId, poolSlotReserved);
+      throw error;
+    }
 
     // Attach event listeners IMMEDIATELY after session start, before any awaits.
     // This prevents a race where rate_limited events emitted during the async
@@ -3365,11 +3399,6 @@ export class DispatchDaemonImpl implements DispatchDaemon {
       assignee: stewardId,
       metadata: finalMetadata,
     });
-
-    // Notify pool service that agent was spawned
-    if (this.poolService) {
-      await this.poolService.onAgentSpawned(stewardId);
-    }
 
     this.emitter.emit('agent:spawned', stewardId, worktreePath);
     logger.info(`Spawned merge steward ${steward.name} for task ${task.id}`);
@@ -3533,16 +3562,25 @@ export class DispatchDaemonImpl implements DispatchDaemon {
     // 4. Build the recovery steward prompt
     const initialPrompt = await this.buildRecoveryStewardPrompt(task, stewardId, taskMeta);
 
+    const poolSlotReserved = await this.reservePoolSlot(stewardId);
+
     // 5. Start the recovery steward session BEFORE unassigning the worker.
     //    If startSession fails (rate limited, pool full, etc.), the task retains
     //    its original worker assignment and is not left orphaned.
-    const { session, events } = await this.sessionManager.startSession(stewardId, {
-      workingDirectory: worktreePath,
-      worktree: worktreePath,
-      initialPrompt,
-      interactive: false, // Stewards use headless mode
-      executablePathOverride: recoveryExecutableOverride ?? undefined,
-    });
+    let session: SessionRecord;
+    let events: EventEmitter;
+    try {
+      ({ session, events } = await this.sessionManager.startSession(stewardId, {
+        workingDirectory: worktreePath,
+        worktree: worktreePath,
+        initialPrompt,
+        interactive: false, // Stewards use headless mode
+        executablePathOverride: recoveryExecutableOverride ?? undefined,
+      }));
+    } catch (error) {
+      await this.releaseReservedPoolSlot(stewardId, poolSlotReserved);
+      throw error;
+    }
 
     // 5a. Attach event listeners IMMEDIATELY after session start, before any awaits.
     //     This prevents a race where rate_limited events emitted during the async
@@ -3602,10 +3640,6 @@ export class DispatchDaemonImpl implements DispatchDaemon {
         );
       }
       throw metadataError;
-    }
-
-    if (this.poolService) {
-      await this.poolService.onAgentSpawned(stewardId);
     }
 
     this.emitter.emit('agent:spawned', stewardId, worktreePath);

--- a/packages/smithy/src/testing/test-context.ts
+++ b/packages/smithy/src/testing/test-context.ts
@@ -512,8 +512,17 @@ export function createMockSessionManager(
   const agentSessions = new Map<EntityId, string>();
   const mockSessions = new Map<string, MockSession>();
   const { EventEmitter } = require('node:events') as typeof import('node:events');
+  const sessionEndedCallbacks = new Set<(session: SessionRecord) => void | Promise<void>>();
 
   let sessionCounter = 0;
+
+  const notifySessionEnded = (session: SessionRecord): void => {
+    for (const callback of sessionEndedCallbacks) {
+      Promise.resolve(callback(session)).catch(() => {
+        // Test helper callbacks are best-effort.
+      });
+    }
+  };
 
   const manager: MockSessionManager = {
     mockSessions,
@@ -564,12 +573,14 @@ export function createMockSessionManager(
 
       const session = sessions.get(sessionId);
       if (session) {
-        sessions.set(sessionId, {
+        const endedSession = {
           ...session,
           status: 'terminated',
           endedAt: createTimestamp(),
-        });
+        } as SessionRecord;
+        sessions.set(sessionId, endedSession);
         agentSessions.delete(session.agentId);
+        notifySessionEnded(endedSession);
       }
     },
 
@@ -644,12 +655,13 @@ export function createMockSessionManager(
         throw new Error(`Session not found: ${sessionId}`);
       }
 
-      sessions.set(sessionId, {
+      const endedSession = {
         ...session,
         status: 'terminated',
         endedAt: createTimestamp(),
         terminationReason: options?.reason,
-      });
+      } as SessionRecord;
+      sessions.set(sessionId, endedSession);
 
       agentSessions.delete(session.agentId);
 
@@ -660,6 +672,7 @@ export function createMockSessionManager(
       }
 
       await agentRegistry.updateAgentSession(session.agentId, undefined, 'idle');
+      notifySessionEnded(endedSession);
     },
 
     async suspendSession(sessionId: string, reason?: string): Promise<void> {
@@ -668,12 +681,13 @@ export function createMockSessionManager(
         throw new Error(`Session not found: ${sessionId}`);
       }
 
-      sessions.set(sessionId, {
+      const suspendedSession = {
         ...session,
         status: 'suspended',
         endedAt: createTimestamp(),
         terminationReason: reason,
-      });
+      } as SessionRecord;
+      sessions.set(sessionId, suspendedSession);
 
       agentSessions.delete(session.agentId);
       await agentRegistry.updateAgentSession(
@@ -681,6 +695,7 @@ export function createMockSessionManager(
         session.providerSessionId,
         'suspended'
       );
+      notifySessionEnded(suspendedSession);
     },
 
     async interruptSession(sessionId: string): Promise<void> {
@@ -815,6 +830,13 @@ export function createMockSessionManager(
 
     setOperationLog(): void {
       // No-op for mock
+    },
+
+    onSessionEnded(callback: (session: SessionRecord) => void | Promise<void>): () => void {
+      sessionEndedCallbacks.add(callback);
+      return () => {
+        sessionEndedCallbacks.delete(callback);
+      };
     },
   };
 


### PR DESCRIPTION
## Summary

Fixes #121.

Agent pool slots are now released when worker or steward sessions terminate, including sessions cleaned up after dead-process detection. This prevents pools from staying full when no governed session is actually running.

## Stacking note

This PR is stacked on upstream PRs #116 and #118. The agent-pool fix itself is in the top five commits on this branch:

- `ff02229` `fix(smithy): release agent pool slots on session end`
- `1f888ec` `fix(smithy): keep pool slots tied to active agents`
- `e2945db` `fix(smithy): reserve pool slots before session start`
- `218eafc` `fix(smithy): wait for session end cleanup before restart`
- `1705e4d` `docs: clarify agent pool changeset`

## Changes

- Add session-ended callbacks to `SessionManager` so pool cleanup can run when sessions leave active execution.
- Register agent-pool cleanup with the Smithy server services.
- Reserve pool slots before provider spawn work can exit, so short-lived failed sessions are still released through the normal session-ended path.
- Ensure dispatch waits for session-end cleanup before immediately starting another session for the same agent.
- Add coverage for session cleanup, pool slot release, and dispatch reuse behavior.

## Test plan

- `bun test packages/smithy/src/runtime/session-manager.bun.test.ts`
- `bun test packages/smithy/src/services/agent-pool-service.bun.test.ts`
- `bun test packages/smithy/src/services/dispatch-daemon.bun.test.ts`
- `corepack pnpm --filter @stoneforge/smithy typecheck`
- `git diff --check`
- Manual sanity check in local Smithy: pool slot releases after worker/steward sessions terminate.

## Checklist

- [x] Tests pass
- [x] Typecheck passes
- [x] Changeset added (if applicable)
